### PR TITLE
Refactor auth module with schema-driven services

### DIFF
--- a/src/modules/auth/api/auth.ts
+++ b/src/modules/auth/api/auth.ts
@@ -2,184 +2,83 @@ import { removeAuthTokens } from '@/lib/auth/tokens'
 import { API_ENDPOINTS } from '@/lib/constants'
 import { api } from '../../../lib/api/config/axios'
 
-// ---------- Types ----------
+import {
+  createProfileRequestSchema,
+  createProfileResponseSchema,
+  getPolicyResponseSchema,
+  loginApiResponseSchema,
+  loginRequestSchema,
+  registerByEmailRequestSchema,
+  registerByEmailResponseSchema,
+  registerByPhoneRequestSchema,
+  registerByPhoneResponseSchema,
+  verifyEmailRequestSchema,
+  verifyEmailResponseSchema,
+  verifyPhoneOtpRequestSchema,
+  type CreateProfileRequest,
+  type CreateProfileResponse,
+  type GetPolicyResponse,
+  type LoginApiResponse,
+  type LoginRequest,
+  type LoginResponse,
+  type RegisterByEmailRequest,
+  type RegisterByEmailResponse,
+  type RegisterByPhoneRequest,
+  type RegisterByPhoneResponse,
+  type VerifyEmailRequest,
+  type VerifyEmailResponse,
+  type VerifyPhoneOtpRequest,
+} from '../schemas'
 
-export interface LoginRequest {
-  phone?: string
-  email?: string
-  password: string
-}
-
-export interface User {
-  customer_id: number
-  email: string
-  phone: string
-  profilename: string
-  avatar: string | null
-  platform_type: string
-  company_id: number | null
-  team_id: number | null
-  device: string
-}
-
-export interface LoginResponse {
-  access_token: string
-  refresh_token: string
-  user: User
-}
-
-export interface ApiResponse<T> {
-  statusCode: number
-  data: T
-  message: string
-}
-
-export interface RegisterByEmailRequest {
-  email: string
-  country_code: string
-}
-
-export interface RegisterByEmailData {
-  message: string
-  userId: number
-  token: string
-}
-
-export interface RegisterByEmailResponse {
-  statusCode: number
-  data: RegisterByEmailData
-  message: string
-}
-
-export interface VerifyEmailRequest {
-  email: string
-  otp: string
-  token: string
-}
-
-export interface VerifyEmailResponse {
-  statusCode: number
-  message: string
-  // เพิ่ม field อื่นๆ ตาม response ที่ backend ส่งกลับ (ถ้ามี)
-}
-
-export interface CreateProfileRequest {
-  email: string
-  country_code: string
-  profilename: string
-  phone: string
-  password: string
-  token: string // register_token
-}
-
-export interface CreateProfileResponse {
-  statusCode: number
-  message: string
-  // เพิ่ม field อื่นๆ ตาม response ที่ backend ส่งกลับ (ถ้ามี)
-}
-
-export interface PolicyDescription {
-  id: number
-  languageId: number
-  policyId: number
-  name: string
-  detail: string
-  createdAt: string
-  createdBy: number
-  updatedAt: string | null
-  updatedBy: number | null
-  policy_id: number
-}
-
-export interface Policy {
-  id: number
-  name: string
-  version: string
-  slug: string
-  status: number
-  deletedAt: string | null
-  createdAt: string
-  createdBy: number
-  updatedAt: string | null
-  updatedBy: number | null
-  descriptions: PolicyDescription[]
-}
-
-export interface GetPolicyResponse {
-  statusCode: number
-  data: Policy[]
-  message: string
-}
-
-export interface RegisterByPhoneRequest {
-  phone: string
-  country_code: string
-}
-
-export interface RegisterByPhoneData {
-  message: string
-  userId: number
-  token: string
-}
-
-export interface RegisterByPhoneResponse {
-  statusCode: number
-  data: RegisterByPhoneData
-  message: string
-}
-
-export interface VerifyPhoneOtpRequest {
-  phone: string
-  otp: string
-  token: string
-}
-// ---------- API Functions ----------
+export type { User } from '../schemas'
 
 export async function loginByPhone(
   request: LoginRequest,
 ): Promise<LoginResponse> {
-  const result = await api.post<ApiResponse<LoginResponse>>(
+  const payload = loginRequestSchema.parse(request)
+  const response = await api.post<LoginApiResponse>(
     API_ENDPOINTS.AUTH.LOGIN,
-    request,
+    payload,
   )
-  return result.data
+  return loginApiResponseSchema.parse(response).data
 }
 
 export async function registerByEmail(
   request: RegisterByEmailRequest,
 ): Promise<RegisterByEmailResponse> {
-  const result = await api.post<RegisterByEmailResponse>(
+  const payload = registerByEmailRequestSchema.parse(request)
+  const response = await api.post<RegisterByEmailResponse>(
     API_ENDPOINTS.AUTH.REGISTER_EMAIL,
-    request,
+    payload,
   )
-  return result
+  return registerByEmailResponseSchema.parse(response)
 }
 
 export async function verifyEmail(
   request: VerifyEmailRequest,
 ): Promise<VerifyEmailResponse> {
-  const result = await api.post<VerifyEmailResponse>(
+  const payload = verifyEmailRequestSchema.parse(request)
+  const response = await api.post<VerifyEmailResponse>(
     API_ENDPOINTS.AUTH.VERIFY_EMAIL,
-    request,
+    payload,
   )
-  return result
+  return verifyEmailResponseSchema.parse(response)
 }
 
 export async function createProfile(
   request: CreateProfileRequest,
 ): Promise<CreateProfileResponse> {
-  const result = await api.post<CreateProfileResponse>(
+  const payload = createProfileRequestSchema.parse(request)
+  const response = await api.post<CreateProfileResponse>(
     API_ENDPOINTS.AUTH.CREATE_PROFILE,
-    request,
+    payload,
   )
-  return result
+  return createProfileResponseSchema.parse(response)
 }
 
 export async function refreshToken(): Promise<LoginResponse> {
-  const result = await api.get<ApiResponse<LoginResponse>>(
-    API_ENDPOINTS.AUTH.REFRESH,
-  )
-  return result.data
+  const response = await api.get<LoginApiResponse>(API_ENDPOINTS.AUTH.REFRESH)
+  return loginApiResponseSchema.parse(response).data
 }
 
 export async function logoutUser(): Promise<void> {
@@ -190,36 +89,29 @@ export async function logoutUser(): Promise<void> {
 }
 
 export async function getPolicy(): Promise<GetPolicyResponse> {
-  const result = await api.get<GetPolicyResponse>(API_ENDPOINTS.AUTH.POLICY)
-  return result
+  const response = await api.get<GetPolicyResponse>(API_ENDPOINTS.AUTH.POLICY)
+  return getPolicyResponseSchema.parse(response)
 }
 
 export async function getTerm(): Promise<GetPolicyResponse> {
-  const result = await api.get<GetPolicyResponse>(API_ENDPOINTS.AUTH.TERM)
-  return result
+  const response = await api.get<GetPolicyResponse>(API_ENDPOINTS.AUTH.TERM)
+  return getPolicyResponseSchema.parse(response)
 }
 
 export async function registerByPhone(
   request: RegisterByPhoneRequest,
 ): Promise<RegisterByPhoneResponse> {
-  const result = await api.post<RegisterByPhoneResponse>(
+  const payload = registerByPhoneRequestSchema.parse(request)
+  const response = await api.post<RegisterByPhoneResponse>(
     API_ENDPOINTS.AUTH.REGISTER_PHONE,
-    request,
+    payload,
   )
-  return result
-}
-
-export interface VerifyPhoneOtpResponse {
-  statusCode: number
-  message: string
+  return registerByPhoneResponseSchema.parse(response)
 }
 
 export async function verifyPhoneOtp(
   request: VerifyPhoneOtpRequest,
-): Promise<VerifyPhoneOtpResponse> {
-  const result = await api.post<VerifyPhoneOtpResponse>(
-    API_ENDPOINTS.AUTH.VERIFY_PHONE,
-    request,
-  )
-  return result
+): Promise<unknown> {
+  const payload = verifyPhoneOtpRequestSchema.parse(request)
+  return api.post(API_ENDPOINTS.AUTH.VERIFY_PHONE, payload)
 }

--- a/src/modules/auth/api/forgot-password.ts
+++ b/src/modules/auth/api/forgot-password.ts
@@ -2,62 +2,95 @@ import { API_ENDPOINTS } from '@/lib/constants'
 import { api } from '../../../lib/api/config/axios'
 import { IResponse } from '../../../lib/api/config/model'
 
-export interface ForgotPasswordEmailRequest {
-  email: string
+import {
+  forgotPasswordEmailRequestSchema,
+  forgotPasswordPhoneRequestSchema,
+  forgotPasswordResponseSchema,
+  resetPasswordRequestSchema,
+  resetPasswordResponseSchema,
+  verifyEmailRequestSchema,
+  verifyOtpResponseSchema,
+  verifyPhoneOtpRequestSchema,
+  type ForgotPasswordEmailRequest,
+  type ForgotPasswordPhoneRequest,
+  type ForgotPasswordResponse,
+  type ResetPasswordRequest,
+  type ResetPasswordResponse,
+  type VerifyEmailRequest,
+  type VerifyOtpResponse,
+  type VerifyPhoneOtpRequest,
+} from '../schemas'
+
+export type {
+  ForgotPasswordEmailRequest,
+  ForgotPasswordPhoneRequest,
+  ResetPasswordRequest,
+  ResetPasswordResponse,
+  VerifyEmailRequest,
+  VerifyOtpResponse,
+  VerifyPhoneOtpRequest,
 }
 
-export interface ForgotPasswordPhoneRequest {
-  phone: string
-}
-
-export interface VerifyEmailOTPRequest {
-  email: string
-  otp: string
-  token: string
-}
-
-export interface VerifyPhoneOTPRequest {
-  phone: string
-  otp: string
-  token: string
-}
-
-export interface ResetPasswordRequest {
-  token: string
-  newPassword: string
-}
-
-export interface ForgotPasswordResponse {
-  token: string
-  message: string
-}
-
-export interface VerifyOTPResponse {
-  token: string
-  message: string
-}
-
-// API Functions
 export const forgotPasswordApi = async (
   data: ForgotPasswordEmailRequest | ForgotPasswordPhoneRequest,
 ): Promise<IResponse<ForgotPasswordResponse>> => {
-  return api.post(API_ENDPOINTS.AUTH.FORGOT_PASSWORD, data)
+  const payload =
+    'email' in data
+      ? forgotPasswordEmailRequestSchema.parse(data)
+      : forgotPasswordPhoneRequestSchema.parse(data)
+
+  const response = await api.post<IResponse<ForgotPasswordResponse>>(
+    API_ENDPOINTS.AUTH.FORGOT_PASSWORD,
+    payload,
+  )
+
+  return {
+    ...response,
+    data: forgotPasswordResponseSchema.parse(response.data),
+  }
 }
 
 export const verifyEmailOTPApi = async (
-  data: VerifyEmailOTPRequest,
-): Promise<IResponse<VerifyOTPResponse>> => {
-  return api.post(API_ENDPOINTS.AUTH.VERIFY_EMAIL, data)
+  data: VerifyEmailRequest,
+): Promise<IResponse<VerifyOtpResponse>> => {
+  const payload = verifyEmailRequestSchema.parse(data)
+  const response = await api.post<IResponse<VerifyOtpResponse>>(
+    API_ENDPOINTS.AUTH.VERIFY_EMAIL,
+    payload,
+  )
+
+  return {
+    ...response,
+    data: verifyOtpResponseSchema.parse(response.data),
+  }
 }
 
 export const verifyPhoneOTPApi = async (
-  data: VerifyPhoneOTPRequest,
-): Promise<IResponse<VerifyOTPResponse>> => {
-  return api.post(API_ENDPOINTS.AUTH.VERIFY_PHONE, data)
+  data: VerifyPhoneOtpRequest,
+): Promise<IResponse<VerifyOtpResponse>> => {
+  const payload = verifyPhoneOtpRequestSchema.parse(data)
+  const response = await api.post<IResponse<VerifyOtpResponse>>(
+    API_ENDPOINTS.AUTH.VERIFY_PHONE,
+    payload,
+  )
+
+  return {
+    ...response,
+    data: verifyOtpResponseSchema.parse(response.data),
+  }
 }
 
 export const resetPasswordApi = async (
   data: ResetPasswordRequest,
-): Promise<IResponse<{ message: string }>> => {
-  return api.post(API_ENDPOINTS.AUTH.RESET_PASSWORD, data)
+): Promise<IResponse<ResetPasswordResponse>> => {
+  const payload = resetPasswordRequestSchema.parse(data)
+  const response = await api.post<IResponse<ResetPasswordResponse>>(
+    API_ENDPOINTS.AUTH.RESET_PASSWORD,
+    payload,
+  )
+
+  return {
+    ...response,
+    data: resetPasswordResponseSchema.parse(response.data),
+  }
 }

--- a/src/modules/auth/api/index.ts
+++ b/src/modules/auth/api/index.ts
@@ -1,0 +1,2 @@
+export * from './auth'
+export * from './forgot-password'

--- a/src/modules/auth/components/forgot-password-dialog.tsx
+++ b/src/modules/auth/components/forgot-password-dialog.tsx
@@ -1,189 +1,71 @@
-"use client";
+"use client"
 
-import { PhoneInput } from "@/components/phone-input";
+import { PhoneInput } from "@/components/phone-input"
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  useForgotPassword,
-  useResetPassword,
-  useVerifyEmailOTP,
-  useVerifyPhoneOTP,
-  type VerifyEmailOTPRequest,
-  type VerifyPhoneOTPRequest,
-} from "@/hooks/use-forgot-password";
-import { formatPhoneForAPI } from "@/lib/utils";
-import { Button } from "@/ui/atoms/button";
-import { Input } from "@/ui/atoms/input";
-import { Eye, EyeOff } from "lucide-react";
-import { useCallback, useState } from "react";
+} from "@/components/ui/dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Button } from "@/ui/atoms/button"
+import { Input } from "@/ui/atoms/input"
+import { Eye, EyeOff } from "lucide-react"
+import { useCallback } from "react"
+
+import { useForgotPasswordDialog } from "../hooks/use-forgot-password-dialog"
 
 interface ForgotPasswordDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  open: boolean
+  onOpenChange: (open: boolean) => void
 }
-
-type Step = "select" | "verify" | "reset";
-type Method = "phone" | "email";
 
 export default function ForgotPasswordDialog({
   open,
   onOpenChange,
 }: ForgotPasswordDialogProps) {
-  const [step, setStep] = useState<Step>("select");
-  const [method, setMethod] = useState<Method>("phone");
-  const [email, setEmail] = useState("");
-  const [phoneValue, setPhoneValue] = useState("");
-  const [otp, setOtp] = useState(["", "", "", "", "", ""]);
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [token, setToken] = useState("");
-
-  const forgotPasswordMutation = useForgotPassword();
-  const verifyEmailMutation = useVerifyEmailOTP();
-  const verifyPhoneMutation = useVerifyPhoneOTP();
-  const resetPasswordMutation = useResetPassword();
-
-  const handleReset = () => {
-    setStep("select");
-    setMethod("phone");
-    setEmail("");
-    setPhoneValue("");
-    setOtp(["", "", "", "", "", ""]);
-    setPassword("");
-    setConfirmPassword("");
-    setToken("");
-  };
+  const {
+    state,
+    step,
+    showPassword,
+    showConfirmPassword,
+    formError,
+    actions,
+    mutations,
+  } = useForgotPasswordDialog()
 
   const handleClose = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        handleReset();
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        actions.reset()
       }
-      onOpenChange(open);
+      onOpenChange(nextOpen)
     },
-    [onOpenChange],
-  );
+    [actions, onOpenChange],
+  )
 
-  // Step 1: Send forgot password request
-  const handleSendOTP = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
+  const handleOtpChange = useCallback(
+    (index: number, value: string) => {
+      actions.setOtpValue(index, value)
 
-      const data =
-        method === "phone"
-          ? { phone: formatPhoneForAPI(phoneValue) }
-          : { email };
-
-      forgotPasswordMutation.mutate(data, {
-        onSuccess: (response) => {
-          setToken(response.data.token);
-          setStep("verify");
-        },
-      });
-    },
-    [method, phoneValue, email, forgotPasswordMutation],
-  );
-
-  // Step 2: Verify OTP
-  const handleVerifyOTP = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-
-      const otpString = otp.join("");
-      if (otpString.length !== 6) return;
-
-      const baseData = {
-        otp: otpString,
-        token,
-      };
-
-      const data =
-        method === "phone"
-          ? { ...baseData, phone: formatPhoneForAPI(phoneValue) }
-          : { ...baseData, email };
-
-      if (method === "phone") {
-        verifyPhoneMutation.mutate(data as VerifyPhoneOTPRequest, {
-          onSuccess: (response) => {
-            setToken(response.data.token);
-            setStep("reset");
-          },
-        });
-      } else {
-        verifyEmailMutation.mutate(data as VerifyEmailOTPRequest, {
-          onSuccess: (response) => {
-            setToken(response.data.token);
-            setStep("reset");
-          },
-        });
+      if (value && index < state.otp.length - 1) {
+        const nextInput = document.querySelector(
+          `input[name="otp-${index + 1}"]`,
+        ) as HTMLInputElement | null
+        nextInput?.focus()
       }
     },
-    [
-      otp,
-      token,
-      method,
-      phoneValue,
-      email,
-      verifyPhoneMutation,
-      verifyEmailMutation,
-    ],
-  );
+    [actions, state.otp.length],
+  )
 
-  const handleResetPassword = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-
-      if (password !== confirmPassword) {
-        return;
-      }
-
-      resetPasswordMutation.mutate(
-        { token, newPassword: password },
-        {
-          onSuccess: () => {
-            handleClose(false);
-          },
-        },
-      );
-    },
-    [password, confirmPassword, token, resetPasswordMutation, handleClose],
-  );
-
-  const handleOtpChange = (index: number, value: string) => {
-    if (value.length > 1) return;
-
-    const newOtp = [...otp];
-    newOtp[index] = value;
-    setOtp(newOtp);
-
-    // Auto focus next input
-    if (value && index < 5) {
-      const nextInput = document.querySelector(
-        `input[name="otp-${index + 1}"]`,
-      ) as HTMLInputElement;
-      nextInput?.focus();
-    }
-  };
-
-  const renderStep = () => {
+  const renderContent = () => {
     switch (step) {
       case "select":
         return (
           <div className="space-y-6">
             <div className="text-center">
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
-                <svg
-                  className="h-6 w-6"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
+                <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
                 </svg>
               </div>
@@ -194,8 +76,10 @@ export default function ForgotPasswordDialog({
             </div>
 
             <Tabs
-              value={method}
-              onValueChange={(value: string) => setMethod(value as Method)}
+              value={state.method}
+              onValueChange={(value: string) =>
+                actions.setMethod(value as "phone" | "email")
+              }
             >
               <TabsList className="grid w-full grid-cols-2 gap-2 bg-transparent">
                 <TabsTrigger
@@ -212,13 +96,13 @@ export default function ForgotPasswordDialog({
                 </TabsTrigger>
               </TabsList>
 
-              <form onSubmit={handleSendOTP} className="mt-6 space-y-4">
+              <form onSubmit={actions.handleSendOtp} className="mt-6 space-y-4">
                 <TabsContent value="phone" className="mt-0">
                   <PhoneInput
                     international
                     defaultCountry="TH"
-                    value={phoneValue}
-                    onChange={setPhoneValue}
+                    value={state.phone}
+                    onChange={actions.setPhone}
                     className="w-full"
                     placeholder="99-902-0922"
                     required
@@ -228,26 +112,32 @@ export default function ForgotPasswordDialog({
                 <TabsContent value="email" className="mt-0">
                   <Input
                     type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    value={state.email}
+                    onChange={(event) => actions.setEmail(event.target.value)}
                     placeholder="onecharge@gmail.com"
                     className="py-3"
                     required
                   />
                 </TabsContent>
 
+                {formError && (
+                  <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                    {formError}
+                  </div>
+                )}
+
                 <Button
                   type="submit"
                   className="w-full"
                   size="lg"
-                  disabled={forgotPasswordMutation.isPending}
+                  disabled={mutations.forgotPassword.isPending}
                 >
-                  {forgotPasswordMutation.isPending ? "Sending..." : "Next"}
+                  {mutations.forgotPassword.isPending ? "Sending..." : "Next"}
                 </Button>
               </form>
             </Tabs>
           </div>
-        );
+        )
 
       case "verify":
         return (
@@ -255,17 +145,17 @@ export default function ForgotPasswordDialog({
             <div className="text-center">
               <h2 className="text-2xl font-bold">Verify OTP</h2>
               <p className="text-blue-600">
-                {method === "phone" ? formatPhoneForAPI(phoneValue) : email}
+                {state.method === "phone" ? state.phone : state.email}
               </p>
               <p className="text-gray-600">
                 Please enter the code received from{" "}
-                {method === "phone" ? "phone SMS Number" : "email"}
+                {state.method === "phone" ? "phone SMS Number" : "email"}
               </p>
             </div>
 
-            <form onSubmit={handleVerifyOTP} className="space-y-6">
+            <form onSubmit={actions.handleVerifyOtp} className="space-y-6">
               <div className="flex justify-center gap-3">
-                {otp.map((digit, index) => (
+                {state.otp.map((digit, index) => (
                   <Input
                     key={index}
                     name={`otp-${index}`}
@@ -274,24 +164,32 @@ export default function ForgotPasswordDialog({
                     pattern="[0-9]"
                     maxLength={1}
                     value={digit}
-                    onChange={(e) => handleOtpChange(index, e.target.value)}
+                    onChange={(event) =>
+                      handleOtpChange(index, event.target.value)
+                    }
                     className="h-14 w-14 text-center text-xl font-semibold"
                     required
                   />
                 ))}
               </div>
 
+              {formError && (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                  {formError}
+                </div>
+              )}
+
               <Button
                 type="submit"
                 className="w-full"
                 size="lg"
                 disabled={
-                  otp.join("").length !== 6 ||
-                  verifyEmailMutation.isPending ||
-                  verifyPhoneMutation.isPending
+                  state.otp.join("").length !== 6 ||
+                  mutations.verifyEmail.isPending ||
+                  mutations.verifyPhone.isPending
                 }
               >
-                {verifyEmailMutation.isPending || verifyPhoneMutation.isPending
+                {mutations.verifyEmail.isPending || mutations.verifyPhone.isPending
                   ? "Verifying..."
                   : "Submit"}
               </Button>
@@ -302,7 +200,7 @@ export default function ForgotPasswordDialog({
               </div>
             </form>
           </div>
-        );
+        )
 
       case "reset":
         return (
@@ -311,14 +209,14 @@ export default function ForgotPasswordDialog({
               <h2 className="text-2xl font-bold">Create New Password</h2>
             </div>
 
-            <form onSubmit={handleResetPassword} className="space-y-4">
+            <form onSubmit={actions.handleResetPassword} className="space-y-4">
               <div className="space-y-2">
                 <label className="text-sm text-blue-600">Password</label>
                 <div className="relative">
                   <Input
                     type={showPassword ? "text" : "password"}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    value={state.password}
+                    onChange={(event) => actions.setPassword(event.target.value)}
                     placeholder="••••••"
                     className="py-3 pr-10"
                     required
@@ -328,26 +226,22 @@ export default function ForgotPasswordDialog({
                     variant="ghost"
                     size="sm"
                     className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                    onClick={() => setShowPassword(!showPassword)}
+                    onClick={actions.togglePasswordVisibility}
                   >
-                    {showPassword ? (
-                      <EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Eye className="h-4 w-4" />
-                    )}
+                    {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </Button>
                 </div>
               </div>
 
               <div className="space-y-2">
-                <label className="text-sm text-gray-600">
-                  Confirm Password
-                </label>
+                <label className="text-sm text-gray-600">Confirm Password</label>
                 <div className="relative">
                   <Input
                     type={showConfirmPassword ? "text" : "password"}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    value={state.confirmPassword}
+                    onChange={(event) =>
+                      actions.setConfirmPassword(event.target.value)
+                    }
                     placeholder="••••••"
                     className="py-3 pr-10"
                     required
@@ -357,7 +251,7 @@ export default function ForgotPasswordDialog({
                     variant="ghost"
                     size="sm"
                     className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                    onClick={actions.toggleConfirmPasswordVisibility}
                   >
                     {showConfirmPassword ? (
                       <EyeOff className="h-4 w-4" />
@@ -368,27 +262,33 @@ export default function ForgotPasswordDialog({
                 </div>
               </div>
 
+              {formError && (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                  {formError}
+                </div>
+              )}
+
               <Button
                 type="submit"
                 className="w-full"
                 size="lg"
                 disabled={
-                  !password ||
-                  !confirmPassword ||
-                  password !== confirmPassword ||
-                  resetPasswordMutation.isPending
+                  !state.password ||
+                  !state.confirmPassword ||
+                  state.password !== state.confirmPassword ||
+                  mutations.resetPassword.isPending
                 }
               >
-                {resetPasswordMutation.isPending ? "Resetting..." : "Submit"}
+                {mutations.resetPassword.isPending ? "Resetting..." : "Submit"}
               </Button>
             </form>
           </div>
-        );
+        )
 
       default:
-        return null;
+        return null
     }
-  };
+  }
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
@@ -396,8 +296,8 @@ export default function ForgotPasswordDialog({
         <DialogHeader className="sr-only">
           <DialogTitle>Forgot Password</DialogTitle>
         </DialogHeader>
-        {renderStep()}
+        {renderContent()}
       </DialogContent>
     </Dialog>
-  );
+  )
 }

--- a/src/modules/auth/components/index.ts
+++ b/src/modules/auth/components/index.ts
@@ -1,7 +1,7 @@
 export { AuthLayout } from './auth-layout'
 
 export { default as CreateProfile } from './create-profile'
-export { default as ForgotPasswordForm } from './forgot-password-dialog'
+export { default as ForgotPasswordDialog } from './forgot-password-dialog'
 export { default as SignInForm } from './signin-form'
 export { default as SignUpForm } from './signup-form'
 export { default as VerifyEmail } from './verify-email'

--- a/src/modules/auth/data/countries.ts
+++ b/src/modules/auth/data/countries.ts
@@ -1,0 +1,11 @@
+import { countryOptionSchema, type CountryOption } from '../schemas'
+
+const countryData: CountryOption[] = [
+  { value: 'TH', label: 'Thai' },
+]
+
+export const COUNTRIES = countryData.map((country) =>
+  countryOptionSchema.parse(country),
+)
+
+export type { CountryOption }

--- a/src/modules/auth/data/index.ts
+++ b/src/modules/auth/data/index.ts
@@ -1,0 +1,1 @@
+export * from './countries'

--- a/src/modules/auth/hooks/index.ts
+++ b/src/modules/auth/hooks/index.ts
@@ -1,1 +1,4 @@
 export { useLogin, useLogout, useUser } from './use-auth'
+export { useForgotPasswordDialog } from './use-forgot-password-dialog'
+export { useSignInForm } from './use-sign-in-form'
+export { useSignUpForm } from './use-sign-up-form'

--- a/src/modules/auth/hooks/use-forgot-password-dialog.ts
+++ b/src/modules/auth/hooks/use-forgot-password-dialog.ts
@@ -1,0 +1,239 @@
+import { useCallback, useState } from 'react'
+
+import {
+  useForgotPassword,
+  useResetPassword,
+  useVerifyEmailOTP,
+  useVerifyPhoneOTP,
+} from '@/hooks/use-forgot-password'
+
+import {
+  buildForgotPasswordRequest,
+  buildResetPasswordRequest,
+  buildVerifyOtpRequest,
+  createInitialForgotPasswordState,
+  type ForgotPasswordPayloadResult,
+  type ForgotPasswordState,
+  type ResetPasswordPayloadResult,
+  type VerifyOtpPayloadResult,
+} from '../services'
+import type { ContactMethod } from '../schemas'
+
+export type ForgotPasswordStep = 'select' | 'verify' | 'reset'
+
+interface UseForgotPasswordDialogActions {
+  setMethod: (method: ContactMethod) => void
+  setEmail: (email: string) => void
+  setPhone: (phone?: string) => void
+  setOtpValue: (index: number, value: string) => void
+  setPassword: (password: string) => void
+  setConfirmPassword: (password: string) => void
+  togglePasswordVisibility: () => void
+  toggleConfirmPasswordVisibility: () => void
+  reset: () => void
+  handleSendOtp: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  handleVerifyOtp: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+  handleResetPassword: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+}
+
+interface UseForgotPasswordDialogResult {
+  state: ForgotPasswordState
+  step: ForgotPasswordStep
+  showPassword: boolean
+  showConfirmPassword: boolean
+  formError: string | null
+  actions: UseForgotPasswordDialogActions
+  mutations: {
+    forgotPassword: ReturnType<typeof useForgotPassword>
+    verifyEmail: ReturnType<typeof useVerifyEmailOTP>
+    verifyPhone: ReturnType<typeof useVerifyPhoneOTP>
+    resetPassword: ReturnType<typeof useResetPassword>
+  }
+}
+
+const extractErrorMessage = (error: unknown): string => {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message?: unknown }).message === 'string'
+  ) {
+    return (error as { message?: string }).message ?? 'Operation failed'
+  }
+
+  return 'Operation failed'
+}
+
+export const useForgotPasswordDialog = (): UseForgotPasswordDialogResult => {
+  const forgotPassword = useForgotPassword()
+  const verifyEmail = useVerifyEmailOTP()
+  const verifyPhone = useVerifyPhoneOTP()
+  const resetPassword = useResetPassword()
+
+  const [state, setState] = useState<ForgotPasswordState>(
+    createInitialForgotPasswordState(),
+  )
+  const [step, setStep] = useState<ForgotPasswordStep>('select')
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const setMethod = useCallback((method: ContactMethod) => {
+    setState((prev) => ({ ...prev, method }))
+  }, [])
+
+  const setEmail = useCallback((email: string) => {
+    setState((prev) => ({ ...prev, email }))
+  }, [])
+
+  const setPhone = useCallback((phone?: string) => {
+    setState((prev) => ({ ...prev, phone: phone ?? '' }))
+  }, [])
+
+  const setOtpValue = useCallback((index: number, value: string) => {
+    if (value.length > 1 || /[^0-9]/.test(value)) {
+      return
+    }
+
+    setState((prev) => {
+      const nextOtp = [...prev.otp]
+      nextOtp[index] = value
+      return { ...prev, otp: nextOtp }
+    })
+  }, [])
+
+  const setPassword = useCallback((password: string) => {
+    setState((prev) => ({ ...prev, password }))
+  }, [])
+
+  const setConfirmPassword = useCallback((password: string) => {
+    setState((prev) => ({ ...prev, confirmPassword: password }))
+  }, [])
+
+  const reset = useCallback(() => {
+    setState(createInitialForgotPasswordState())
+    setStep('select')
+    setShowPassword(false)
+    setShowConfirmPassword(false)
+    setFormError(null)
+  }, [])
+
+  const togglePasswordVisibility = useCallback(() => {
+    setShowPassword((prev) => !prev)
+  }, [])
+
+  const toggleConfirmPasswordVisibility = useCallback(() => {
+    setShowConfirmPassword((prev) => !prev)
+  }, [])
+
+  const handleSendOtp = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const result: ForgotPasswordPayloadResult = buildForgotPasswordRequest(state)
+
+      if (!result.success) {
+        setFormError(result.error)
+        return
+      }
+
+      setFormError(null)
+
+      try {
+        const { method, payload } = result.data
+        const response = await forgotPassword.mutateAsync(payload)
+        setState((prev) => ({ ...prev, token: response.data.token }))
+        setStep('verify')
+      } catch (error: unknown) {
+        setFormError(extractErrorMessage(error))
+      }
+    },
+    [forgotPassword, state],
+  )
+
+  const handleVerifyOtp = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const result: VerifyOtpPayloadResult = buildVerifyOtpRequest(state)
+
+      if (!result.success) {
+        setFormError(result.error)
+        return
+      }
+
+      setFormError(null)
+
+      try {
+        const { method, payload } = result.data
+
+        if (method === 'phone') {
+          const response = await verifyPhone.mutateAsync(payload)
+          setState((prev) => ({ ...prev, token: response.data.token }))
+          setStep('reset')
+          return
+        }
+
+        const response = await verifyEmail.mutateAsync(payload)
+        setState((prev) => ({ ...prev, token: response.data.token }))
+        setStep('reset')
+      } catch (error: unknown) {
+        setFormError(extractErrorMessage(error))
+      }
+    },
+    [state, verifyEmail, verifyPhone],
+  )
+
+  const handleResetPassword = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const result: ResetPasswordPayloadResult = buildResetPasswordRequest(state)
+
+      if (!result.success) {
+        setFormError(result.error)
+        return
+      }
+
+      setFormError(null)
+
+      try {
+        await resetPassword.mutateAsync(result.data)
+        reset()
+      } catch (error: unknown) {
+        setFormError(extractErrorMessage(error))
+      }
+    },
+    [reset, resetPassword, state],
+  )
+
+  const actions: UseForgotPasswordDialogActions = {
+    setMethod,
+    setEmail,
+    setPhone,
+    setOtpValue,
+    setPassword,
+    setConfirmPassword,
+    togglePasswordVisibility,
+    toggleConfirmPasswordVisibility,
+    reset,
+    handleSendOtp,
+    handleVerifyOtp,
+    handleResetPassword,
+  }
+
+  return {
+    state,
+    step,
+    showPassword,
+    showConfirmPassword,
+    formError,
+    actions,
+    mutations: {
+      forgotPassword,
+      verifyEmail,
+      verifyPhone,
+      resetPassword,
+    },
+  }
+}

--- a/src/modules/auth/hooks/use-sign-in-form.ts
+++ b/src/modules/auth/hooks/use-sign-in-form.ts
@@ -1,0 +1,105 @@
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react'
+
+import { useLogin } from './use-auth'
+import {
+  buildLoginPayload,
+  createInitialSignInState,
+  type SignInPayloadResult,
+} from '../services'
+import type { ContactMethod, SignInFormState } from '../schemas'
+
+interface UseSignInFormActions {
+  setMethod: (method: ContactMethod) => void
+  setEmail: (email: string) => void
+  setPhone: (phone?: string) => void
+  setPassword: (password: string) => void
+  setKeepLoggedIn: (keepLoggedIn: boolean) => void
+  togglePasswordVisibility: () => void
+  setShowForgotPassword: (open: boolean) => void
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void
+}
+
+interface UseSignInFormResult {
+  state: SignInFormState
+  showPassword: boolean
+  showForgotPassword: boolean
+  formError: string | null
+  loginMutation: ReturnType<typeof useLogin>
+  actions: UseSignInFormActions
+}
+
+const updateState = (
+  updater: (prev: SignInFormState) => SignInFormState,
+  setState: Dispatch<SetStateAction<SignInFormState>>,
+) => {
+  setState((prev) => updater(prev))
+}
+
+export const useSignInForm = (): UseSignInFormResult => {
+  const loginMutation = useLogin()
+  const [state, setState] = useState<SignInFormState>(createInitialSignInState)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showForgotPassword, setShowForgotPassword] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const setMethod = useCallback((method: ContactMethod) => {
+    updateState((prev) => ({ ...prev, method }), setState)
+  }, [])
+
+  const setEmail = useCallback((email: string) => {
+    updateState((prev) => ({ ...prev, email }), setState)
+  }, [])
+
+  const setPhone = useCallback((phone?: string) => {
+    updateState((prev) => ({ ...prev, phone: phone ?? '' }), setState)
+  }, [])
+
+  const setPassword = useCallback((password: string) => {
+    updateState((prev) => ({ ...prev, password }), setState)
+  }, [])
+
+  const setKeepLoggedIn = useCallback((keepLoggedIn: boolean) => {
+    updateState((prev) => ({ ...prev, keepLoggedIn }), setState)
+  }, [])
+
+  const togglePasswordVisibility = useCallback(() => {
+    setShowPassword((prev) => !prev)
+  }, [])
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const result: SignInPayloadResult = buildLoginPayload(state)
+
+      if (!result.success) {
+        setFormError(result.error)
+        return
+      }
+
+      setFormError(null)
+      loginMutation.mutate(result.data)
+    },
+    [loginMutation, state],
+  )
+
+  const actions: UseSignInFormActions = {
+    setMethod,
+    setEmail,
+    setPhone,
+    setPassword,
+    setKeepLoggedIn,
+    togglePasswordVisibility,
+    setShowForgotPassword,
+    handleSubmit,
+  }
+
+  return {
+    state,
+    showPassword,
+    showForgotPassword,
+    formError,
+    loginMutation,
+    actions,
+  }
+}

--- a/src/modules/auth/hooks/use-sign-up-form.ts
+++ b/src/modules/auth/hooks/use-sign-up-form.ts
@@ -1,0 +1,201 @@
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from 'react'
+import { useRouter } from 'next/navigation'
+
+import { useRegisterByEmail, useRegisterByPhone } from './use-auth'
+import { COUNTRIES, type CountryOption } from '../data'
+import {
+  buildSignUpPayload,
+  createInitialSignUpState,
+  filterCountries,
+  type SignUpPayloadResult,
+} from '../services'
+import type { ContactMethod, SignUpFormState } from '../schemas'
+
+interface UseSignUpFormActions {
+  setMethod: (method: ContactMethod) => void
+  setEmail: (email: string) => void
+  setPhone: (phone?: string) => void
+  setCountry: (country: string) => void
+  setAcceptedTerms: (accepted: boolean) => void
+  setSearchQuery: (query: string) => void
+  setPolicyDialogOpen: (open: boolean) => void
+  handleCheckboxClick: (checked?: boolean | 'indeterminate') => void
+  handleAcceptPolicy: () => void
+  handleSubmit: (event: React.FormEvent<HTMLFormElement>) => Promise<void>
+}
+
+interface UseSignUpFormResult {
+  state: SignUpFormState
+  searchQuery: string
+  policyDialogOpen: boolean
+  formError: string | null
+  countries: CountryOption[]
+  filteredCountries: CountryOption[]
+  registerByEmail: ReturnType<typeof useRegisterByEmail>
+  registerByPhone: ReturnType<typeof useRegisterByPhone>
+  actions: UseSignUpFormActions
+}
+
+const updateState = (
+  updater: (prev: SignUpFormState) => SignUpFormState,
+  setState: Dispatch<SetStateAction<SignUpFormState>>,
+) => {
+  setState((prev) => updater(prev))
+}
+
+const extractErrorMessage = (error: unknown): string => {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    Array.isArray((error as { message?: unknown }).message)
+  ) {
+    return (error as { message: string[] }).message.join('\n')
+  }
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message?: unknown }).message === 'string'
+  ) {
+    return (error as { message?: string }).message ?? 'Registration failed'
+  }
+
+  return 'Registration failed'
+}
+
+export const useSignUpForm = (): UseSignUpFormResult => {
+  const router = useRouter()
+  const registerByEmail = useRegisterByEmail()
+  const registerByPhone = useRegisterByPhone()
+
+  const [state, setState] = useState<SignUpFormState>(createInitialSignUpState)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [policyDialogOpen, setPolicyDialogOpen] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const setMethod = useCallback((method: ContactMethod) => {
+    updateState((prev) => ({ ...prev, method }), setState)
+  }, [])
+
+  const setEmail = useCallback((email: string) => {
+    updateState((prev) => ({ ...prev, email }), setState)
+  }, [])
+
+  const setPhone = useCallback((phone?: string) => {
+    updateState((prev) => ({ ...prev, phone: phone ?? '' }), setState)
+  }, [])
+
+  const setCountry = useCallback((country: string) => {
+    updateState((prev) => ({ ...prev, country }), setState)
+  }, [])
+
+  const setAcceptedTerms = useCallback((accepted: boolean) => {
+    updateState((prev) => ({ ...prev, acceptedTerms: accepted }), setState)
+  }, [])
+
+  const updateSearchQuery = useCallback((query: string) => {
+    setSearchQuery(query)
+  }, [])
+
+  const updatePolicyDialogOpen = useCallback((open: boolean) => {
+    setPolicyDialogOpen(open)
+  }, [])
+
+  const handleCheckboxClick = useCallback(
+    (checked?: boolean | 'indeterminate') => {
+      if (!state.acceptedTerms) {
+        setPolicyDialogOpen(true)
+        return
+      }
+
+      setAcceptedTerms(false)
+    },
+    [setAcceptedTerms, state.acceptedTerms],
+  )
+
+  const handleAcceptPolicy = useCallback(() => {
+    setAcceptedTerms(true)
+    setPolicyDialogOpen(false)
+  }, [setAcceptedTerms])
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+
+      const result: SignUpPayloadResult = buildSignUpPayload(state)
+
+      if (!result.success) {
+        setFormError(result.error)
+        return
+      }
+
+      setFormError(null)
+
+      const { method, payload } = result.data
+
+      try {
+        if (method === 'email') {
+          const response = await registerByEmail.mutateAsync(payload)
+
+          if (response.statusCode === 201) {
+            router.push('/verify-email')
+            return
+          }
+
+          setFormError(response.message ?? 'Registration failed')
+          return
+        }
+
+        const response = await registerByPhone.mutateAsync(payload)
+
+        if (response.statusCode === 201) {
+          router.push('/verify-phone')
+          return
+        }
+
+        setFormError(response.message ?? 'Registration failed')
+      } catch (error: unknown) {
+        setFormError(extractErrorMessage(error))
+      }
+    },
+    [registerByEmail, registerByPhone, router, state],
+  )
+
+  const filteredCountries = useMemo(
+    () => filterCountries(COUNTRIES, searchQuery),
+    [searchQuery],
+  )
+
+  const actions: UseSignUpFormActions = {
+    setMethod,
+    setEmail,
+    setPhone,
+    setCountry,
+    setAcceptedTerms,
+    setSearchQuery: updateSearchQuery,
+    setPolicyDialogOpen: updatePolicyDialogOpen,
+    handleCheckboxClick,
+    handleAcceptPolicy,
+    handleSubmit,
+  }
+
+  return {
+    state,
+    searchQuery,
+    policyDialogOpen,
+    formError,
+    countries: COUNTRIES,
+    filteredCountries,
+    registerByEmail,
+    registerByPhone,
+    actions,
+  }
+}

--- a/src/modules/auth/index.ts
+++ b/src/modules/auth/index.ts
@@ -1,2 +1,6 @@
+export * from './api'
 export * from './components'
+export * from './data'
 export * from './hooks'
+export * from './schemas'
+export * from './services'

--- a/src/modules/auth/schemas/auth-api.schema.ts
+++ b/src/modules/auth/schemas/auth-api.schema.ts
@@ -1,0 +1,210 @@
+import { z } from 'zod'
+
+const optionalEmailSchema = z
+  .string({ required_error: 'Email is required' })
+  .email('Invalid email address')
+
+const optionalPhoneSchema = z
+  .string({ required_error: 'Phone number is required' })
+  .min(1, 'Phone number is required')
+
+export const loginRequestSchema = z
+  .object({
+    phone: optionalPhoneSchema.optional(),
+    email: optionalEmailSchema.optional(),
+    password: z.string({ required_error: 'Password is required' }).min(1),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.phone && !value.email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Either phone or email must be provided',
+        path: ['phone'],
+      })
+    }
+
+    if (value.phone && value.email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide only a phone number or an email address',
+        path: ['phone'],
+      })
+    }
+  })
+
+export const userSchema = z.object({
+  customer_id: z.number(),
+  email: z.string(),
+  phone: z.string(),
+  profilename: z.string(),
+  avatar: z.string().nullable(),
+  platform_type: z.string(),
+  company_id: z.number().nullable(),
+  team_id: z.number().nullable(),
+  device: z.string(),
+})
+
+export const loginResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  user: userSchema,
+})
+
+export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
+
+const apiResponseBaseSchema = z.object({
+  statusCode: z.number(),
+  message: z.string(),
+})
+
+export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  apiResponseBaseSchema.extend({
+    data: dataSchema,
+  })
+
+export const registerByEmailRequestSchema = z.object({
+  email: optionalEmailSchema,
+  country_code: z.string({ required_error: 'Country code is required' }).min(1),
+})
+
+export const registerByEmailDataSchema = z.object({
+  message: z.string(),
+  userId: z.number(),
+  token: z.string(),
+})
+
+export const registerByEmailResponseSchema = createApiResponseSchema(
+  registerByEmailDataSchema,
+)
+
+export const verifyEmailRequestSchema = z.object({
+  email: optionalEmailSchema,
+  otp: z.string({ required_error: 'OTP is required' }).min(1),
+  token: z.string({ required_error: 'Token is required' }),
+})
+
+export const verifyEmailResponseSchema = apiResponseBaseSchema
+
+export const registerByPhoneRequestSchema = z.object({
+  phone: optionalPhoneSchema,
+  country_code: z.string({ required_error: 'Country code is required' }).min(1),
+})
+
+export const registerByPhoneDataSchema = z.object({
+  message: z.string(),
+  userId: z.number(),
+  token: z.string(),
+})
+
+export const registerByPhoneResponseSchema = createApiResponseSchema(
+  registerByPhoneDataSchema,
+)
+
+export const verifyPhoneOtpRequestSchema = z.object({
+  phone: optionalPhoneSchema,
+  otp: z.string({ required_error: 'OTP is required' }).min(1),
+  token: z.string({ required_error: 'Token is required' }),
+})
+
+export const forgotPasswordEmailRequestSchema = z.object({
+  email: optionalEmailSchema,
+})
+
+export const forgotPasswordPhoneRequestSchema = z.object({
+  phone: optionalPhoneSchema,
+})
+
+export const forgotPasswordResponseSchema = z.object({
+  token: z.string(),
+  message: z.string(),
+})
+
+export const verifyOtpResponseSchema = z.object({
+  token: z.string(),
+  message: z.string(),
+})
+
+export const resetPasswordRequestSchema = z.object({
+  token: z.string({ required_error: 'Token is required' }),
+  newPassword: z
+    .string({ required_error: 'New password is required' })
+    .min(6, 'Password must be at least 6 characters long'),
+})
+
+export const resetPasswordResponseSchema = z.object({
+  message: z.string(),
+})
+
+export const createProfileRequestSchema = z.object({
+  email: optionalEmailSchema.or(z.literal('')).optional(),
+  country_code: z
+    .string({ required_error: 'Country code is required' })
+    .min(1, 'Country code is required'),
+  profilename: z
+    .string({ required_error: 'Profile name is required' })
+    .min(1, 'Profile name is required'),
+  phone: optionalPhoneSchema.or(z.literal('')).optional(),
+  password: z
+    .string({ required_error: 'Password is required' })
+    .min(1, 'Password is required'),
+  token: z.string({ required_error: 'Token is required' }),
+})
+
+export const createProfileResponseSchema = apiResponseBaseSchema
+
+export const policyDescriptionSchema = z.object({
+  id: z.number(),
+  languageId: z.number(),
+  policyId: z.number(),
+  name: z.string(),
+  detail: z.string(),
+  createdAt: z.string(),
+  createdBy: z.number(),
+  updatedAt: z.string().nullable(),
+  updatedBy: z.number().nullable(),
+  policy_id: z.number(),
+})
+
+export const policySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  version: z.string(),
+  slug: z.string(),
+  status: z.number(),
+  deletedAt: z.string().nullable(),
+  createdAt: z.string(),
+  createdBy: z.number(),
+  updatedAt: z.string().nullable(),
+  updatedBy: z.number().nullable(),
+  descriptions: z.array(policyDescriptionSchema),
+})
+
+export const getPolicyResponseSchema = createApiResponseSchema(z.array(policySchema))
+
+export type LoginRequest = z.infer<typeof loginRequestSchema>
+export type User = z.infer<typeof userSchema>
+export type LoginResponse = z.infer<typeof loginResponseSchema>
+export type LoginApiResponse = z.infer<typeof loginApiResponseSchema>
+export type RegisterByEmailRequest = z.infer<typeof registerByEmailRequestSchema>
+export type RegisterByEmailData = z.infer<typeof registerByEmailDataSchema>
+export type RegisterByEmailResponse = z.infer<typeof registerByEmailResponseSchema>
+export type VerifyEmailRequest = z.infer<typeof verifyEmailRequestSchema>
+export type VerifyEmailResponse = z.infer<typeof verifyEmailResponseSchema>
+export type RegisterByPhoneRequest = z.infer<typeof registerByPhoneRequestSchema>
+export type RegisterByPhoneData = z.infer<typeof registerByPhoneDataSchema>
+export type RegisterByPhoneResponse = z.infer<typeof registerByPhoneResponseSchema>
+export type VerifyPhoneOtpRequest = z.infer<typeof verifyPhoneOtpRequestSchema>
+export type CreateProfileRequest = z.infer<typeof createProfileRequestSchema>
+export type CreateProfileResponse = z.infer<typeof createProfileResponseSchema>
+export type Policy = z.infer<typeof policySchema>
+export type GetPolicyResponse = z.infer<typeof getPolicyResponseSchema>
+export type ForgotPasswordEmailRequest = z.infer<
+  typeof forgotPasswordEmailRequestSchema
+>
+export type ForgotPasswordPhoneRequest = z.infer<
+  typeof forgotPasswordPhoneRequestSchema
+>
+export type ForgotPasswordResponse = z.infer<typeof forgotPasswordResponseSchema>
+export type VerifyOtpResponse = z.infer<typeof verifyOtpResponseSchema>
+export type ResetPasswordRequest = z.infer<typeof resetPasswordRequestSchema>
+export type ResetPasswordResponse = z.infer<typeof resetPasswordResponseSchema>

--- a/src/modules/auth/schemas/auth-forms.schema.ts
+++ b/src/modules/auth/schemas/auth-forms.schema.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod'
+
+export const contactMethodSchema = z.enum(['phone', 'email'])
+
+export const signInFormStateSchema = z.object({
+  method: contactMethodSchema.default('phone'),
+  phone: z.string().optional(),
+  email: z.string().optional(),
+  password: z.string().default(''),
+  keepLoggedIn: z.boolean().default(false),
+})
+
+export const signInFormSchema = signInFormStateSchema
+  .extend({
+    password: z
+      .string({ required_error: 'Password is required' })
+      .min(1, 'Password is required'),
+  })
+  .superRefine((value, ctx) => {
+    if (value.method === 'phone' && !value.phone) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Phone number is required',
+        path: ['phone'],
+      })
+    }
+
+    if (value.method === 'email' && !value.email) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Email is required',
+        path: ['email'],
+      })
+    }
+  })
+
+export const signUpFormStateSchema = z.object({
+  method: contactMethodSchema.default('email'),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  country: z.string().min(1, 'Country is required'),
+  acceptedTerms: z.boolean(),
+})
+
+export const signUpByEmailSchema = signUpFormStateSchema
+  .extend({
+    method: z.literal('email'),
+    email: z
+      .string({ required_error: 'Email is required' })
+      .email('Invalid email address'),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.acceptedTerms) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Please accept the Privacy Policy and Terms Condition',
+        path: ['acceptedTerms'],
+      })
+    }
+  })
+
+export const signUpByPhoneSchema = signUpFormStateSchema
+  .extend({
+    method: z.literal('phone'),
+    phone: z
+      .string({ required_error: 'Phone number is required' })
+      .min(1, 'Phone number is required'),
+  })
+  .superRefine((value, ctx) => {
+    if (!value.acceptedTerms) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Please accept the Privacy Policy and Terms Condition',
+        path: ['acceptedTerms'],
+      })
+    }
+  })
+
+export const signUpFormSchema = z.discriminatedUnion('method', [
+  signUpByEmailSchema,
+  signUpByPhoneSchema,
+])
+
+export const forgotPasswordRequestSchema = z.discriminatedUnion('method', [
+  z.object({
+    method: z.literal('phone'),
+    phone: z
+      .string({ required_error: 'Phone number is required' })
+      .min(1, 'Phone number is required'),
+  }),
+  z.object({
+    method: z.literal('email'),
+    email: z
+      .string({ required_error: 'Email is required' })
+      .email('Invalid email address'),
+  }),
+])
+
+const otpSchema = z
+  .string({ required_error: 'OTP is required' })
+  .length(6, 'OTP must be 6 digits')
+  .regex(/^[0-9]+$/, 'OTP must contain only digits')
+
+export const verifyOtpSchema = z.object({
+  method: contactMethodSchema,
+  otp: otpSchema,
+  token: z.string({ required_error: 'Token is required' }),
+  phone: z.string().optional(),
+  email: z.string().optional(),
+})
+
+export const resetPasswordSchema = z
+  .object({
+    password: z
+      .string({ required_error: 'Password is required' })
+      .min(6, 'Password must be at least 6 characters long'),
+    confirmPassword: z
+      .string({ required_error: 'Confirm password is required' })
+      .min(6, 'Confirm password must be at least 6 characters long'),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['confirmPassword'],
+        message: 'Passwords do not match',
+      })
+    }
+  })
+
+export const countryOptionSchema = z.object({
+  value: z.string(),
+  label: z.string(),
+})
+
+export type ContactMethod = z.infer<typeof contactMethodSchema>
+export type SignInFormState = z.infer<typeof signInFormStateSchema>
+export type SignInFormInput = z.infer<typeof signInFormSchema>
+export type SignUpFormState = z.infer<typeof signUpFormStateSchema>
+export type SignUpByEmailInput = z.infer<typeof signUpByEmailSchema>
+export type SignUpByPhoneInput = z.infer<typeof signUpByPhoneSchema>
+export type SignUpFormInput = z.infer<typeof signUpFormSchema>
+export type ForgotPasswordRequestInput = z.infer<typeof forgotPasswordRequestSchema>
+export type VerifyOtpInput = z.infer<typeof verifyOtpSchema>
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>
+export type CountryOption = z.infer<typeof countryOptionSchema>

--- a/src/modules/auth/schemas/index.ts
+++ b/src/modules/auth/schemas/index.ts
@@ -1,0 +1,2 @@
+export * from './auth-api.schema'
+export * from './auth-forms.schema'

--- a/src/modules/auth/services/forgot-password.service.ts
+++ b/src/modules/auth/services/forgot-password.service.ts
@@ -1,0 +1,133 @@
+import { formatPhoneForAPI } from '@/lib/utils'
+
+import {
+  forgotPasswordRequestSchema,
+  resetPasswordSchema,
+  verifyOtpSchema,
+  type VerifyOtpInput,
+} from '../schemas'
+
+export interface ForgotPasswordState {
+  method: 'phone' | 'email'
+  email: string
+  phone: string
+  otp: string[]
+  password: string
+  confirmPassword: string
+  token: string
+}
+
+export const createInitialForgotPasswordState = (): ForgotPasswordState => ({
+  method: 'phone',
+  email: '',
+  phone: '',
+  otp: Array(6).fill(''),
+  password: '',
+  confirmPassword: '',
+  token: '',
+})
+
+export type ForgotPasswordPayload =
+  | { method: 'phone'; payload: { phone: string } }
+  | { method: 'email'; payload: { email: string } }
+
+export type ForgotPasswordPayloadResult =
+  | { success: true; data: ForgotPasswordPayload }
+  | { success: false; error: string }
+
+export const buildForgotPasswordRequest = (
+  state: Pick<ForgotPasswordState, 'method' | 'phone' | 'email'>,
+): ForgotPasswordPayloadResult => {
+  const parsed = forgotPasswordRequestSchema.safeParse({
+    method: state.method,
+    ...(state.method === 'phone'
+      ? { phone: formatPhoneForAPI(state.phone) }
+      : { email: state.email }),
+  })
+
+  if (!parsed.success) {
+    const error = parsed.error.errors.at(0)
+    return { success: false, error: error?.message ?? 'Invalid contact details' }
+  }
+
+  return {
+    success: true,
+    data:
+      parsed.data.method === 'phone'
+        ? { method: 'phone', payload: { phone: parsed.data.phone } }
+        : { method: 'email', payload: { email: parsed.data.email } },
+  }
+}
+
+export type VerifyOtpPayload =
+  | { method: 'phone'; payload: VerifyOtpInput & { phone: string } }
+  | { method: 'email'; payload: VerifyOtpInput & { email: string } }
+
+export type VerifyOtpPayloadResult =
+  | { success: true; data: VerifyOtpPayload }
+  | { success: false; error: string }
+
+export const buildVerifyOtpRequest = (
+  state: Pick<ForgotPasswordState, 'method' | 'phone' | 'email' | 'otp' | 'token'>,
+): VerifyOtpPayloadResult => {
+  const otpValue = state.otp.join('')
+
+  const parsed = verifyOtpSchema.safeParse({
+    method: state.method,
+    otp: otpValue,
+    token: state.token,
+    ...(state.method === 'phone'
+      ? { phone: formatPhoneForAPI(state.phone) }
+      : { email: state.email }),
+  })
+
+  if (!parsed.success) {
+    const error = parsed.error.errors.at(0)
+    return { success: false, error: error?.message ?? 'Invalid OTP' }
+  }
+
+  return {
+    success: true,
+    data:
+      parsed.data.method === 'phone'
+        ? {
+            method: 'phone',
+            payload: {
+              ...parsed.data,
+              phone: formatPhoneForAPI(state.phone),
+            },
+          }
+        : {
+            method: 'email',
+            payload: {
+              ...parsed.data,
+              email: state.email,
+            },
+          },
+  }
+}
+
+export type ResetPasswordPayload = { token: string; newPassword: string }
+
+export type ResetPasswordPayloadResult =
+  | { success: true; data: ResetPasswordPayload }
+  | { success: false; error: string }
+
+export const buildResetPasswordRequest = (
+  state: Pick<ForgotPasswordState, 'password' | 'confirmPassword' | 'token'>,
+): ResetPasswordPayloadResult => {
+  const parsed = resetPasswordSchema.safeParse({
+    password: state.password,
+    confirmPassword: state.confirmPassword,
+  })
+
+  if (!parsed.success) {
+    const error = parsed.error.errors.at(0)
+    return { success: false, error: error?.message ?? 'Invalid password' }
+  }
+
+  return {
+    success: true,
+    data: { token: state.token, newPassword: parsed.data.password },
+  }
+}

--- a/src/modules/auth/services/index.ts
+++ b/src/modules/auth/services/index.ts
@@ -1,0 +1,3 @@
+export * from './forgot-password.service'
+export * from './sign-in.service'
+export * from './sign-up.service'

--- a/src/modules/auth/services/sign-in.service.ts
+++ b/src/modules/auth/services/sign-in.service.ts
@@ -1,0 +1,58 @@
+import { formatPhoneForAPI } from '@/lib/utils/phone'
+
+import {
+  loginRequestSchema,
+  signInFormSchema,
+  type LoginRequest,
+  type SignInFormState,
+} from '../schemas'
+
+export const createInitialSignInState = (): SignInFormState => ({
+  method: 'phone',
+  phone: '',
+  email: '',
+  password: '',
+  keepLoggedIn: false,
+})
+
+export type SignInPayloadResult =
+  | { success: true; data: LoginRequest }
+  | { success: false; error: string }
+
+export const buildLoginPayload = (
+  state: SignInFormState,
+): SignInPayloadResult => {
+  const parsedForm = signInFormSchema.safeParse(state)
+
+  if (!parsedForm.success) {
+    const error = parsedForm.error.errors.at(0)
+    return {
+      success: false,
+      error: error?.message ?? 'Invalid credentials',
+    }
+  }
+
+  const { method, phone, email, password } = parsedForm.data
+
+  const payloadCandidate = {
+    ...(method === 'phone'
+      ? { phone: formatPhoneForAPI(phone ?? '') }
+      : { email: email ?? '' }),
+    password,
+  }
+
+  const parsedPayload = loginRequestSchema.safeParse(payloadCandidate)
+
+  if (!parsedPayload.success) {
+    const error = parsedPayload.error.errors.at(0)
+    return {
+      success: false,
+      error: error?.message ?? 'Invalid credentials',
+    }
+  }
+
+  return {
+    success: true,
+    data: parsedPayload.data,
+  }
+}

--- a/src/modules/auth/services/sign-up.service.ts
+++ b/src/modules/auth/services/sign-up.service.ts
@@ -1,0 +1,99 @@
+import { parsePhoneNumberFromString, type CountryCode } from 'libphonenumber-js'
+
+import {
+  registerByEmailRequestSchema,
+  registerByPhoneRequestSchema,
+  signUpFormSchema,
+  type RegisterByEmailRequest,
+  type RegisterByPhoneRequest,
+  type SignUpFormState,
+} from '../schemas'
+
+import type { CountryOption } from '../data'
+
+export const createInitialSignUpState = (): SignUpFormState => ({
+  method: 'email',
+  email: '',
+  phone: '',
+  country: '',
+  acceptedTerms: false,
+})
+
+export const normalizePhoneNumber = (phone: string, country: string): string => {
+  const countryCode = (country || 'TH') as CountryCode
+  const phoneNumber = parsePhoneNumberFromString(phone, countryCode)
+  return phoneNumber ? phoneNumber.formatNational().replace(/\D/g, '') : phone
+}
+
+export const filterCountries = (
+  countries: CountryOption[],
+  query: string,
+): CountryOption[] => {
+  if (!query) return countries
+  const normalizedQuery = query.toLowerCase()
+  return countries.filter((country) =>
+    country.label.toLowerCase().includes(normalizedQuery),
+  )
+}
+
+export type SignUpPayload =
+  | { method: 'email'; payload: RegisterByEmailRequest }
+  | { method: 'phone'; payload: RegisterByPhoneRequest }
+
+export type SignUpPayloadResult =
+  | { success: true; data: SignUpPayload }
+  | { success: false; error: string }
+
+export const buildSignUpPayload = (
+  state: SignUpFormState,
+): SignUpPayloadResult => {
+  const parsedForm = signUpFormSchema.safeParse(state)
+
+  if (!parsedForm.success) {
+    const error = parsedForm.error.errors.at(0)
+    return {
+      success: false,
+      error: error?.message ?? 'Invalid form data',
+    }
+  }
+
+  const { method, email, phone, country } = parsedForm.data
+
+  if (method === 'email') {
+    const parsedPayload = registerByEmailRequestSchema.safeParse({
+      email,
+      country_code: country,
+    })
+
+    if (!parsedPayload.success) {
+      const error = parsedPayload.error.errors.at(0)
+      return {
+        success: false,
+        error: error?.message ?? 'Invalid email registration data',
+      }
+    }
+
+    return {
+      success: true,
+      data: { method, payload: parsedPayload.data },
+    }
+  }
+
+  const parsedPayload = registerByPhoneRequestSchema.safeParse({
+    phone: normalizePhoneNumber(phone ?? '', country),
+    country_code: country,
+  })
+
+  if (!parsedPayload.success) {
+    const error = parsedPayload.error.errors.at(0)
+    return {
+      success: false,
+      error: error?.message ?? 'Invalid phone registration data',
+    }
+  }
+
+  return {
+    success: true,
+    data: { method, payload: parsedPayload.data },
+  }
+}


### PR DESCRIPTION
## Summary
- add zod-based schemas for auth forms, API payloads, and shared types alongside country data helpers
- introduce dedicated services and hooks to encapsulate auth form logic for sign-in, sign-up, and forgot-password flows
- refactor components and API clients to consume the new hooks/services, enforce validation, and expand barrel exports across the auth module

## Testing
- `pnpm lint:check` *(fails: unable to download pnpm due to network/proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cadc5a98f0832e92492a08bb33b37e