### PR TITLE
Fix auth API schema initialization order

### DIFF
--- a/src/modules/auth/schemas/auth-api.schema.ts
+++ b/src/modules/auth/schemas/auth-api.schema.ts
@@ -50,8 +50,6 @@ export const loginResponseSchema = z.object({
   user: userSchema,
 })
 
-export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
-
 const apiResponseBaseSchema = z.object({
   statusCode: z.number(),
   message: z.string(),
@@ -61,6 +59,8 @@ export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =
   apiResponseBaseSchema.extend({
     data: dataSchema,
   })
+
+export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
 
 export const registerByEmailRequestSchema = z.object({
   email: optionalEmailSchema,


### PR DESCRIPTION
## Summary
- define the shared API response schema utilities before they are used
- ensure createApiResponseSchema is initialized ahead of loginApiResponseSchema to avoid runtime reference errors

## Testing
- pnpm lint:check *(fails: network proxy prevents downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68cae3710764832eb6415ac609450f15