### PR TITLE
Fix auth API schema initialization order

### DIFF
--- a/src/modules/auth/schemas/auth-api.schema.ts
+++ b/src/modules/auth/schemas/auth-api.schema.ts
@@ -50,8 +50,6 @@ export const loginResponseSchema = z.object({
   user: userSchema,
 })
 
-export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
-
 const apiResponseBaseSchema = z.object({
   statusCode: z.number(),
   message: z.string(),
@@ -61,6 +59,8 @@ export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =
   apiResponseBaseSchema.extend({
     data: dataSchema,
   })
+
+export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
 
 export const registerByEmailRequestSchema = z.object({
   email: optionalEmailSchema,

--- a/src/modules/auth/schemas/auth-forms.schema.ts
+++ b/src/modules/auth/schemas/auth-forms.schema.ts
@@ -42,44 +42,44 @@ export const signUpFormStateSchema = z.object({
   acceptedTerms: z.boolean(),
 })
 
-export const signUpByEmailSchema = signUpFormStateSchema
-  .extend({
-    method: z.literal('email'),
-    email: z
-      .string({ required_error: 'Email is required' })
-      .email('Invalid email address'),
-  })
-  .superRefine((value, ctx) => {
+const requireAcceptedTermsMessage =
+  'Please accept the Privacy Policy and Terms Condition'
+
+const withAcceptedTerms = <Schema extends z.ZodTypeAny>(schema: Schema) =>
+  schema.superRefine((value, ctx) => {
     if (!value.acceptedTerms) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Please accept the Privacy Policy and Terms Condition',
+        message: requireAcceptedTermsMessage,
         path: ['acceptedTerms'],
       })
     }
   })
 
-export const signUpByPhoneSchema = signUpFormStateSchema
-  .extend({
-    method: z.literal('phone'),
-    phone: z
-      .string({ required_error: 'Phone number is required' })
-      .min(1, 'Phone number is required'),
-  })
-  .superRefine((value, ctx) => {
-    if (!value.acceptedTerms) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Please accept the Privacy Policy and Terms Condition',
-        path: ['acceptedTerms'],
-      })
-    }
-  })
+const signUpByEmailObjectSchema = signUpFormStateSchema.extend({
+  method: z.literal('email'),
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Invalid email address'),
+})
 
-export const signUpFormSchema = z.discriminatedUnion('method', [
-  signUpByEmailSchema,
-  signUpByPhoneSchema,
-])
+const signUpByPhoneObjectSchema = signUpFormStateSchema.extend({
+  method: z.literal('phone'),
+  phone: z
+    .string({ required_error: 'Phone number is required' })
+    .min(1, 'Phone number is required'),
+})
+
+export const signUpByEmailSchema = withAcceptedTerms(signUpByEmailObjectSchema)
+
+export const signUpByPhoneSchema = withAcceptedTerms(signUpByPhoneObjectSchema)
+
+export const signUpFormSchema = withAcceptedTerms(
+  z.discriminatedUnion('method', [
+    signUpByEmailObjectSchema,
+    signUpByPhoneObjectSchema,
+  ]),
+)
 
 export const forgotPasswordRequestSchema = z.discriminatedUnion('method', [
   z.object({


### PR DESCRIPTION
## Summary
- define the shared API response schema utilities before they are used
- ensure createApiResponseSchema is initialized ahead of loginApiResponseSchema to avoid runtime reference errors
- restructure the sign-up form schemas so the discriminated union options are plain objects while accepted-term validation is shared, preventing runtime initialization errors

## Testing
- pnpm lint *(fails: proxy 403 when downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68cae3710764832eb6415ac609450f15