### PR TITLE
Fix auth API schema initialization order

### DIFF
--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -1,4 +1,10 @@
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+const FALLBACK_API_BASE_URL = '/api'
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL &&
+  process.env.NEXT_PUBLIC_API_BASE_URL.trim().length > 0
+    ? process.env.NEXT_PUBLIC_API_BASE_URL.replace(/\/$/, '')
+    : FALLBACK_API_BASE_URL
 
 export const API_ENDPOINTS = {
   AUTH: {

--- a/src/modules/auth/schemas/auth-api.schema.ts
+++ b/src/modules/auth/schemas/auth-api.schema.ts
@@ -50,8 +50,6 @@ export const loginResponseSchema = z.object({
   user: userSchema,
 })
 
-export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
-
 const apiResponseBaseSchema = z.object({
   statusCode: z.number(),
   message: z.string(),
@@ -61,6 +59,8 @@ export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =
   apiResponseBaseSchema.extend({
     data: dataSchema,
   })
+
+export const loginApiResponseSchema = createApiResponseSchema(loginResponseSchema)
 
 export const registerByEmailRequestSchema = z.object({
   email: optionalEmailSchema,

--- a/src/modules/auth/schemas/auth-forms.schema.ts
+++ b/src/modules/auth/schemas/auth-forms.schema.ts
@@ -42,44 +42,44 @@ export const signUpFormStateSchema = z.object({
   acceptedTerms: z.boolean(),
 })
 
-export const signUpByEmailSchema = signUpFormStateSchema
-  .extend({
-    method: z.literal('email'),
-    email: z
-      .string({ required_error: 'Email is required' })
-      .email('Invalid email address'),
-  })
-  .superRefine((value, ctx) => {
+const requireAcceptedTermsMessage =
+  'Please accept the Privacy Policy and Terms Condition'
+
+const withAcceptedTerms = <Schema extends z.ZodTypeAny>(schema: Schema) =>
+  schema.superRefine((value, ctx) => {
     if (!value.acceptedTerms) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Please accept the Privacy Policy and Terms Condition',
+        message: requireAcceptedTermsMessage,
         path: ['acceptedTerms'],
       })
     }
   })
 
-export const signUpByPhoneSchema = signUpFormStateSchema
-  .extend({
-    method: z.literal('phone'),
-    phone: z
-      .string({ required_error: 'Phone number is required' })
-      .min(1, 'Phone number is required'),
-  })
-  .superRefine((value, ctx) => {
-    if (!value.acceptedTerms) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Please accept the Privacy Policy and Terms Condition',
-        path: ['acceptedTerms'],
-      })
-    }
-  })
+const signUpByEmailObjectSchema = signUpFormStateSchema.extend({
+  method: z.literal('email'),
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Invalid email address'),
+})
 
-export const signUpFormSchema = z.discriminatedUnion('method', [
-  signUpByEmailSchema,
-  signUpByPhoneSchema,
-])
+const signUpByPhoneObjectSchema = signUpFormStateSchema.extend({
+  method: z.literal('phone'),
+  phone: z
+    .string({ required_error: 'Phone number is required' })
+    .min(1, 'Phone number is required'),
+})
+
+export const signUpByEmailSchema = withAcceptedTerms(signUpByEmailObjectSchema)
+
+export const signUpByPhoneSchema = withAcceptedTerms(signUpByPhoneObjectSchema)
+
+export const signUpFormSchema = withAcceptedTerms(
+  z.discriminatedUnion('method', [
+    signUpByEmailObjectSchema,
+    signUpByPhoneObjectSchema,
+  ]),
+)
 
 export const forgotPasswordRequestSchema = z.discriminatedUnion('method', [
   z.object({


### PR DESCRIPTION
## Summary
- define the shared API response schema utilities before they are used
- ensure createApiResponseSchema is initialized ahead of loginApiResponseSchema to avoid runtime reference errors
- restructure the sign-up form schemas so the discriminated union options are plain objects while accepted-term validation is shared, preventing runtime initialization errors
- default the API base URL to the internal /api proxy when the public environment variable is missing so auth requests bypass the locale middleware and reach the backend

## Testing
- pnpm lint *(fails: proxy 403 when downloading pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68cae3710764832eb6415ac609450f15