### PR TITLE
Fix auth user schema parsing for API variations

### DIFF
--- a/src/modules/auth/schemas/auth-api.schema.ts
+++ b/src/modules/auth/schemas/auth-api.schema.ts
@@ -32,16 +32,64 @@ export const loginRequestSchema = z
     }
   })
 
+const numericStringToNumberSchema = z.string().transform((value, ctx) => {
+  const trimmedValue = value.trim()
+
+  if (trimmedValue.length === 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Expected number, received empty string',
+    })
+
+    return z.NEVER
+  }
+
+  const normalisedValue = trimmedValue.replace(/[,_\s]/g, '')
+  const numericPattern = /^[-+]?\d+(\.\d+)?$/
+
+  if (!numericPattern.test(normalisedValue)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Expected number, received non-numeric string',
+    })
+
+    return z.NEVER
+  }
+
+  const parsedNumber = Number(normalisedValue)
+
+  if (!Number.isFinite(parsedNumber)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Expected number, received NaN',
+    })
+
+    return z.NEVER
+  }
+
+  return parsedNumber
+})
+
+const numericSchema = z.union([z.number(), numericStringToNumberSchema])
+
+const nullableNumericSchema = numericSchema.nullable()
+
+const nullableStringToStringSchema = z
+  .union([z.string(), z.null()])
+  .transform((value) => value ?? '')
+
 export const userSchema = z.object({
-  customer_id: z.number(),
-  email: z.string(),
-  phone: z.string(),
+  customer_id: numericSchema,
+  email: z
+    .union([z.string().email(), z.null()])
+    .transform((value) => value ?? ''),
+  phone: nullableStringToStringSchema,
   profilename: z.string(),
   avatar: z.string().nullable(),
   platform_type: z.string(),
-  company_id: z.number().nullable(),
-  team_id: z.number().nullable(),
-  device: z.string(),
+  company_id: nullableNumericSchema,
+  team_id: nullableNumericSchema,
+  device: nullableStringToStringSchema,
 })
 
 export const loginResponseSchema = z.object({


### PR DESCRIPTION
## Summary
- coerce numeric identifiers in the auth user schema so API string values are accepted
- normalise nullable string fields (email, phone, device) to avoid parsing failures when the API returns nulls
- strip commas, spaces, and underscores from numeric identifier strings before coercing so formatted values no longer parse to `NaN`

## Testing
- pnpm lint:check *(fails: unable to download pnpm@10.16.1 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cae8efde18832e85f9f15b682f7333