### PR TITLE
Add localized route helper and update navigation usage

### DIFF
--- a/src/app/[locale]/(back-office)/team/team-add/page.tsx
+++ b/src/app/[locale]/(back-office)/team/team-add/page.tsx
@@ -5,6 +5,7 @@ import { SuccessDialog } from "@/components/notifications";
 import { Button } from "@/components/ui/button";
 import { useCreateTeam, useTeamHostId } from "@/hooks/use-teams";
 import { ROUTES } from "@/lib/constants";
+import { buildLocalizedPath } from "@/lib/helpers/localized-path";
 import { useI18n } from "@/lib/i18n";
 import { TeamFormData } from "@/lib/schemas/team";
 import { colors } from "@/lib/utils/colors";
@@ -16,12 +17,12 @@ const TeamAddPage = () => {
   const router = useRouter();
   const teamHostId = useTeamHostId();
   const createTeamMutation = useCreateTeam();
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
 
   const handleBack = () => {
-    router.push(ROUTES.TEAM);
+    router.push(buildLocalizedPath(locale, ROUTES.TEAM));
   };
 
   const handleSubmit = async (data: TeamFormData) => {
@@ -66,7 +67,7 @@ const TeamAddPage = () => {
 
   const handleDialogClose = () => {
     setShowSuccessDialog(false);
-    router.push(ROUTES.TEAM);
+    router.push(buildLocalizedPath(locale, ROUTES.TEAM));
   };
 
   return (

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { ROUTES } from "@/lib/constants";
+import { buildLocalizedPath } from "@/lib/helpers/localized-path";
 import type { Locale } from "@/middleware";
 import { redirect } from "next/navigation";
 
@@ -8,5 +9,5 @@ interface HomePageProps {
 
 export default async function HomePage({ params }: HomePageProps) {
   const { locale } = await params;
-  redirect(`/${locale}${ROUTES.SIGN_IN}`);
+  redirect(buildLocalizedPath(locale, ROUTES.SIGN_IN));
 }

--- a/src/components/back-office/team/team-tabs.tsx
+++ b/src/components/back-office/team/team-tabs.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { ROUTES } from "@/lib/constants";
+import { buildLocalizedPath } from "@/lib/helpers/localized-path";
+import { useI18n } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -15,17 +17,23 @@ export function TeamTabs({ teamId, activeTab }: TeamTabsProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { locale } = useI18n();
 
   // เมื่อโหลดคอมโพเนนต์ ถ้าอยู่ที่หน้า team/[id] ให้นำทางไปยัง overview
   useEffect(() => {
-    const teamPath = ROUTES.TEAM + `/${teamId}`;
+    const teamPath = buildLocalizedPath(locale, `${ROUTES.TEAM}/${teamId}`);
     if (pathname === teamPath) {
-      router.push(ROUTES.TEAM_OVERVIEW.replace("[id]", teamId));
+      router.push(
+        buildLocalizedPath(
+          locale,
+          ROUTES.TEAM_OVERVIEW.replace("[id]", teamId),
+        ),
+      );
     }
-  }, [pathname, teamId, router]);
+  }, [pathname, teamId, router, locale]);
 
   // Function to preserve URL parameters when navigating
-  const getHrefWithParams = (baseHref: string) => {
+  const getHrefWithParams = (baseHref: string, localizedBaseHref: string) => {
     const currentParams = new URLSearchParams();
 
     // Keep only page and pageSize parameters for chargers page
@@ -38,7 +46,9 @@ export function TeamTabs({ teamId, activeTab }: TeamTabsProps) {
     }
 
     const queryString = currentParams.toString();
-    return queryString ? `${baseHref}?${queryString}` : baseHref;
+    return queryString
+      ? `${localizedBaseHref}?${queryString}`
+      : localizedBaseHref;
   };
 
   const tabs = [
@@ -93,7 +103,9 @@ export function TeamTabs({ teamId, activeTab }: TeamTabsProps) {
     <div className="overflow-x-auto rounded-lg bg-card px-2 py-2">
       <div className="flex min-w-max font-semibold">
         {tabs.map((tab) => {
-          const isCurrentPath = pathname === tab.href;
+          const localizedHref = buildLocalizedPath(locale, tab.href);
+          const hrefWithParams = getHrefWithParams(tab.href, localizedHref);
+          const isCurrentPath = pathname === localizedHref;
 
           // ถ้าเป็นหน้าปัจจุบัน ให้ใช้ button แทน Link เพื่อป้องกันการนำทางซ้ำ
           if (isCurrentPath) {
@@ -115,7 +127,7 @@ export function TeamTabs({ teamId, activeTab }: TeamTabsProps) {
           return (
             <Link
               key={tab.id}
-              href={getHrefWithParams(tab.href)}
+              href={hrefWithParams}
               className={cn(
                 "min-w-[100px] flex-1 truncate px-4 py-2 text-center text-sm transition-colors",
                 activeTab === tab.id

--- a/src/lib/helpers/localized-path.ts
+++ b/src/lib/helpers/localized-path.ts
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+
+import { useI18n } from "../i18n";
+
+type RouteLike = string;
+
+/**
+ * Prefixes the provided route with the given locale while preserving any existing
+ * query string or hash fragments.
+ */
+export function buildLocalizedPath(locale: string, route: RouteLike) {
+  if (typeof route !== "string" || route.length === 0) {
+    return route;
+  }
+
+  if (!route.startsWith("/")) {
+    return route;
+  }
+
+  const normalizedLocale = locale.replace(/^\/+|\/+$/g, "");
+
+  if (!normalizedLocale) {
+    return route;
+  }
+
+  if (
+    route === `/${normalizedLocale}` ||
+    route.startsWith(`/${normalizedLocale}/`)
+  ) {
+    return route;
+  }
+
+  const [pathname, ...suffixParts] = route.split(/(?=[?#])/);
+  const suffix = suffixParts.join("");
+
+  const normalizedPathname =
+    pathname && pathname !== "/"
+      ? pathname.startsWith("/")
+        ? pathname
+        : `/${pathname}`
+      : "";
+
+  const basePath = normalizedPathname
+    ? `/${normalizedLocale}${normalizedPathname}`
+    : `/${normalizedLocale}`;
+
+  return `${basePath}${suffix}`;
+}
+
+/**
+ * Returns a memoized helper that prefixes routes with the current locale.
+ */
+export function useLocalizedRoutes() {
+  const { locale } = useI18n();
+
+  return useCallback(
+    (route: RouteLike) => buildLocalizedPath(locale, route),
+    [locale],
+  );
+}

--- a/src/modules/auth/hooks/use-auth.ts
+++ b/src/modules/auth/hooks/use-auth.ts
@@ -4,6 +4,8 @@ import {
   setAuthTokens,
 } from '@/lib/auth/tokens'
 import { QUERY_KEYS, ROUTES } from '@/lib/constants'
+import { buildLocalizedPath } from '@/lib/helpers/localized-path'
+import { useI18n } from '@/lib/i18n'
 import {
   createProfile,
   loginByPhone,
@@ -21,6 +23,7 @@ import { useEffect, useState } from 'react'
 export function useLogin() {
   const router = useRouter()
   const queryClient = useQueryClient()
+  const { locale } = useI18n()
 
   return useMutation({
     mutationFn: loginByPhone,
@@ -48,7 +51,7 @@ export function useLogin() {
         }
         router.push(decodeURIComponent(redirectAfterLogin))
       } else {
-        router.push(ROUTES.DASHBOARD)
+        router.push(buildLocalizedPath(locale, ROUTES.DASHBOARD))
       }
     },
     onError: (error) => {
@@ -113,6 +116,7 @@ export function useUser() {
 export function useLogout() {
   const router = useRouter()
   const queryClient = useQueryClient()
+  const { locale } = useI18n()
 
   return useMutation({
     mutationFn: logoutUser,
@@ -126,7 +130,7 @@ export function useLogout() {
         localStorage.removeItem('user_data')
       }
       // redirect ไปหน้า login
-      router.push(ROUTES.SIGN_IN)
+      router.push(buildLocalizedPath(locale, ROUTES.SIGN_IN))
     },
     onError: (error) => {
       console.error('Logout failed:', error)
@@ -137,7 +141,7 @@ export function useLogout() {
         localStorage.removeItem('user_data')
       }
 
-      router.push(ROUTES.SIGN_IN)
+      router.push(buildLocalizedPath(locale, ROUTES.SIGN_IN))
     },
   })
 }


### PR DESCRIPTION
## Summary
- add a reusable `buildLocalizedPath` helper (and hook) to prefix routes with the active locale
- update auth redirects, team creation flows, and team tabs navigation to build locale-aware paths while retaining query params
- adjust the locale landing page redirect to use the new helper

## Testing
- pnpm lint:check *(fails: corepack could not download pnpm 10.16.1 because of the restricted network/proxy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cafa71cedc832e9c3afc4aadf93f71