### PR TITLE
Fix team list cache query filters

### DIFF
--- a/src/modules/teams/hooks/use-teams/cache-helpers.ts
+++ b/src/modules/teams/hooks/use-teams/cache-helpers.ts
@@ -1,18 +1,17 @@
-import type { QueryClient } from "@tanstack/react-query";
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
 
 import { QUERY_KEYS } from "@/lib/constants";
 
 import type { TeamListQueryResponse } from "@/modules/teams/schemas";
 
-export type TeamListCacheEntry = [readonly unknown[], TeamListQueryResponse | undefined];
+export type TeamListCacheEntry = [QueryKey, TeamListQueryResponse | undefined];
 
 export const getTeamListCaches = (
   queryClient: QueryClient
 ): TeamListCacheEntry[] => {
-  return queryClient.getQueriesData<TeamListQueryResponse>([
-    QUERY_KEYS.TEAMS,
-    "list",
-  ]);
+  return queryClient.getQueriesData<TeamListQueryResponse>({
+    queryKey: [QUERY_KEYS.TEAMS, "list"],
+  });
 };
 
 export const updateTeamListCaches = (


### PR DESCRIPTION
## Summary
- use a typed query key when requesting cached team list data from React Query
- tighten the cached entry type to use React Query's QueryKey

## Testing
- pnpm lint:check *(fails: unable to download pnpm due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0d09527c832e882f99887f4b89e4