### PR TITLE
Fix charging station type errors

### DIFF
--- a/src/modules/charging-stations/components/charging-station-form.tsx
+++ b/src/modules/charging-stations/components/charging-station-form.tsx
@@ -44,8 +44,8 @@ interface ChargingStationFormProps {
   openCloseDialogOpen: boolean
   uploadedFiles: File[]
   dayLabels: Record<DayOfWeek, string>
-  existingGallery?: { id: number; image: string; sort_order: number }[] // เพิ่มรูปที่มีอยู่แล้ว
-  allGalleryImages?: { id: number; image: string; sort_order: number }[] // รูปทั้งหมดรวมที่จะลบ
+  existingGallery?: { id: number; image: string; sort_order?: number }[] // เพิ่มรูปที่มีอยู่แล้ว
+  allGalleryImages?: { id: number; image: string; sort_order?: number }[] // รูปทั้งหมดรวมที่จะลบ
   deletedImageIds?: number[] // เพิ่มรายการ ID ของรูปที่จะลบ
   maxImages?: number // เพิ่มจำนวนรูปสูงสุด
   remainingSlots?: number // เพิ่มจำนวนที่เหลือ
@@ -527,12 +527,12 @@ export function ChargingStationForm({
             {existingGallery.length > 0 && (
               <div className="mt-4 space-y-2">
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
-                  {existingGallery.map((item) => (
+                  {existingGallery.map((item, index) => (
                     <div key={item.id} className="relative">
                       <div className="aspect-square overflow-hidden rounded-lg border">
                         <Image
                           src={item.image}
-                          alt={`Station image ${item.sort_order}`}
+                          alt={`Station image ${item.sort_order ?? index + 1}`}
                           className="h-full w-full object-cover"
                           width={100}
                           height={100}

--- a/src/modules/charging-stations/components/charging-stations-page.tsx
+++ b/src/modules/charging-stations/components/charging-stations-page.tsx
@@ -8,11 +8,12 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { useI18n } from '@/lib/i18n'
 import { useChargingStationsPageController } from '@/modules/charging-stations/hooks'
+import { ChevronDown, Plus, Search } from 'lucide-react'
+import type { JSX } from 'react'
+import { useParams } from 'next/navigation'
 import AddChargingStationDialog from './add-charging-station-dialog'
 import { ChargingStationsTable } from './charging-stations-table'
 import EditsChargingStationDialog from './edits-charging-station-dialog'
-import { ChevronDown, Plus, Search } from 'lucide-react'
-import { useParams } from 'next/navigation'
 
 interface ChargingStationsPageProps {
   teamId: string


### PR DESCRIPTION
## Summary
- allow charging station gallery props to accept optional sort order values and improve alt text fallback
- add JSX type import to charging stations page to satisfy type checking

## Testing
- `pnpm lint` *(fails: unable to download pnpm due to network/proxy restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68cb19b11f60832ea13fed24604fbe7f