### PR TITLE
Refactor map client logic into hook and service

### DIFF
--- a/src/src/components/maps/hooks/use-map-client.ts
+++ b/src/src/components/maps/hooks/use-map-client.ts
@@ -1,0 +1,738 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { ChangeEvent, KeyboardEvent, MouseEvent, RefObject } from 'react'
+import L from 'leaflet'
+
+import type { MapClientProps, MapSearchResult } from '../types'
+import {
+  geocodeAddress as geocodeAddressService,
+  reverseGeocode as reverseGeocodeService,
+  searchAddresses as searchAddressesService,
+} from '../services/nominatim-service'
+
+const defaultIcon = L.icon({
+  iconUrl: '/assets/images/icons/pinmaps.svg',
+  iconRetinaUrl: '/assets/images/icons/pinmaps.svg',
+  shadowUrl: '/assets/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
+const FALLBACK_PIN_LABEL = 'ตำแหน่งที่ระบุ'
+const CURRENT_POSITION_LABEL = 'ตำแหน่งปัจจุบัน'
+const FALLBACK_LOCATION = {
+  lat: 13.7563,
+  lng: 100.5018,
+  address: 'กรุงเทพมหานคร (ตำแหน่งเริ่มต้น)',
+}
+const LOCATION_UNSUPPORTED_MESSAGE = 'เบราว์เซอร์ไม่รองรับการหาตำแหน่ง'
+
+const SEARCH_DEBOUNCE_MS = 150
+const REVERSE_GEOCODE_DEBOUNCE_MS = 300
+const MAP_PIN_THROTTLE_MS = 300
+const MIN_PAN_DISTANCE_METERS = 100
+const MAP_DEFAULT_ZOOM = 15
+
+export type UseMapClientProps = Omit<MapClientProps, 'width' | 'height'>
+
+export interface UseMapClientResult {
+  address: string
+  isGeocodingLoading: boolean
+  showSuggestions: boolean
+  searchResults: MapSearchResult[]
+  selectedSuggestionIndex: number
+  isLoadingLocation: boolean
+  isPinMode: boolean
+  locationError: string | null
+  latitude: number | null
+  longitude: number | null
+  mapRef: RefObject<HTMLDivElement>
+  searchContainerRef: RefObject<HTMLDivElement>
+  handleAddressChange: (event: ChangeEvent<HTMLInputElement>) => void
+  handleAddressSearch: (event: KeyboardEvent<HTMLInputElement>) => void
+  handleAddressFocus: () => void
+  handleLatitudeChange: (event: ChangeEvent<HTMLInputElement>) => void
+  handleLongitudeChange: (event: ChangeEvent<HTMLInputElement>) => void
+  selectSearchResult: (result: MapSearchResult) => void
+  togglePinMode: (event: MouseEvent<HTMLButtonElement>) => void
+}
+
+export function useMapClient({
+  onCoordinatesChange,
+  onAddressChange,
+  initialCoordinates,
+  initialAddress,
+}: UseMapClientProps): UseMapClientResult {
+  const mapRef = useRef<HTMLDivElement>(null)
+  const mapInstanceRef = useRef<L.Map | null>(null)
+  const markerRef = useRef<L.Marker | null>(null)
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const geocodeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const searchContainerRef = useRef<HTMLDivElement>(null)
+  const abortControllerRef = useRef<AbortController | null>(null)
+  const isCleaningUpRef = useRef(false)
+  const isMapInitializedRef = useRef(false)
+  const lastGeocodedCoordsRef = useRef<string>('')
+  const lastPinClickRef = useRef(0)
+
+  const [latitude, setLatitude] = useState<number | null>(
+    initialCoordinates?.lat ?? null,
+  )
+  const [longitude, setLongitude] = useState<number | null>(
+    initialCoordinates?.lng ?? null,
+  )
+  const [address, setAddress] = useState<string>(initialAddress ?? '')
+  const [currentLocationName, setCurrentLocationName] =
+    useState<string>(CURRENT_POSITION_LABEL)
+  const [isLoadingLocation, setIsLoadingLocation] = useState(true)
+  const [isGeocodingLoading, setIsGeocodingLoading] = useState(false)
+  const [searchResults, setSearchResults] = useState<MapSearchResult[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(false)
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1)
+  const [isPinMode, setIsPinMode] = useState(false)
+  const [locationError, setLocationError] = useState<string | null>(null)
+
+  const currentCoordinates = useMemo(() => {
+    if (latitude === null || longitude === null) return null
+    return { lat: latitude, lng: longitude }
+  }, [latitude, longitude])
+
+  const cleanupMap = useCallback(() => {
+    if (isCleaningUpRef.current) return
+    isCleaningUpRef.current = true
+
+    try {
+      if (markerRef.current) {
+        markerRef.current = null
+      }
+
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.off()
+        mapInstanceRef.current.remove()
+        mapInstanceRef.current = null
+      }
+
+      isMapInitializedRef.current = false
+    } catch (error) {
+      console.error('Error during map cleanup:', error)
+    } finally {
+      isCleaningUpRef.current = false
+    }
+  }, [])
+
+  const updateMarker = useCallback(
+    (lat: number, lng: number, popupText: string) => {
+      if (!mapInstanceRef.current) return
+
+      try {
+        if (
+          markerRef.current &&
+          mapInstanceRef.current.hasLayer(markerRef.current)
+        ) {
+          mapInstanceRef.current.removeLayer(markerRef.current)
+        }
+
+        const newMarker = L.marker([lat, lng], {
+          icon: defaultIcon,
+          riseOnHover: true,
+        }).addTo(mapInstanceRef.current)
+
+        markerRef.current = newMarker
+        newMarker.bindPopup(popupText)
+
+        newMarker.openPopup()
+        setTimeout(() => {
+          if (
+            newMarker &&
+            mapInstanceRef.current &&
+            mapInstanceRef.current.hasLayer(newMarker)
+          ) {
+            newMarker.closePopup()
+          }
+        }, 2000)
+      } catch (error) {
+        console.error('Error updating marker:', error)
+      }
+    },
+    [],
+  )
+
+  const debouncedReverseGeocode = useCallback(
+    async (lat: number, lng: number) => {
+      const coordKey = `${lat.toFixed(4)},${lng.toFixed(4)}`
+
+      if (lastGeocodedCoordsRef.current === coordKey) return
+
+      if (geocodeTimeoutRef.current) {
+        clearTimeout(geocodeTimeoutRef.current)
+      }
+
+      geocodeTimeoutRef.current = setTimeout(async () => {
+        try {
+          setIsGeocodingLoading(true)
+          lastGeocodedCoordsRef.current = coordKey
+
+          const displayName = await reverseGeocodeService(lat, lng)
+          const fallbackName = displayName ?? FALLBACK_PIN_LABEL
+
+          setCurrentLocationName(fallbackName)
+          setAddress(fallbackName)
+          onAddressChange?.(fallbackName)
+
+          updateMarker(lat, lng, fallbackName)
+        } catch (error) {
+          console.error('Reverse geocoding error:', error)
+          setCurrentLocationName(FALLBACK_PIN_LABEL)
+          setAddress(FALLBACK_PIN_LABEL)
+          onAddressChange?.(FALLBACK_PIN_LABEL)
+
+          updateMarker(lat, lng, FALLBACK_PIN_LABEL)
+        } finally {
+          setIsGeocodingLoading(false)
+        }
+      }, REVERSE_GEOCODE_DEBOUNCE_MS)
+    },
+    [onAddressChange, updateMarker],
+  )
+
+  const handleCoordinateChange = useCallback(
+    async (lat: number, lng: number, skipGeocode = false) => {
+      const roundedLat = parseFloat(lat.toFixed(4))
+      const roundedLng = parseFloat(lng.toFixed(4))
+
+      setLatitude(roundedLat)
+      setLongitude(roundedLng)
+
+      onCoordinatesChange?.(roundedLat, roundedLng)
+
+      if (mapInstanceRef.current) {
+        const currentCenter = mapInstanceRef.current.getCenter()
+        const distance = currentCenter.distanceTo([roundedLat, roundedLng])
+
+        if (distance > MIN_PAN_DISTANCE_METERS) {
+          mapInstanceRef.current.panTo([roundedLat, roundedLng], {
+            animate: true,
+            duration: 0.5,
+          })
+        }
+      }
+
+      if (!skipGeocode) {
+        debouncedReverseGeocode(roundedLat, roundedLng)
+      }
+    },
+    [onCoordinatesChange, debouncedReverseGeocode],
+  )
+
+  useEffect(() => {
+    if (
+      initialCoordinates &&
+      initialCoordinates.lat !== 0 &&
+      initialCoordinates.lng !== 0
+    ) {
+      setLatitude(initialCoordinates.lat)
+      setLongitude(initialCoordinates.lng)
+      if (initialAddress) {
+        setAddress(initialAddress)
+        setCurrentLocationName(initialAddress)
+      }
+      setIsLoadingLocation(false)
+      return
+    }
+
+    if (!navigator.geolocation) {
+      console.error('Geolocation is not supported by this browser.')
+      setLocationError(LOCATION_UNSUPPORTED_MESSAGE)
+
+      setLatitude(FALLBACK_LOCATION.lat)
+      setLongitude(FALLBACK_LOCATION.lng)
+      setCurrentLocationName(FALLBACK_LOCATION.address)
+      setAddress(FALLBACK_LOCATION.address)
+      setIsLoadingLocation(false)
+
+      onCoordinatesChange?.(
+        parseFloat(FALLBACK_LOCATION.lat.toFixed(4)),
+        parseFloat(FALLBACK_LOCATION.lng.toFixed(4)),
+      )
+      onAddressChange?.(FALLBACK_LOCATION.address)
+
+      setTimeout(() => setLocationError(null), 5000)
+      return
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const { latitude: currentLat, longitude: currentLng } = position.coords
+        setLatitude(currentLat)
+        setLongitude(currentLng)
+
+        try {
+          const displayName = await reverseGeocodeService(
+            currentLat,
+            currentLng,
+          )
+          const resolvedName = displayName ?? CURRENT_POSITION_LABEL
+          setCurrentLocationName(resolvedName)
+          setAddress(resolvedName)
+          onAddressChange?.(resolvedName)
+        } catch (error) {
+          console.error('Reverse geocoding error:', error)
+          setCurrentLocationName(CURRENT_POSITION_LABEL)
+          setAddress(CURRENT_POSITION_LABEL)
+          onAddressChange?.(CURRENT_POSITION_LABEL)
+        }
+
+        onCoordinatesChange?.(
+          parseFloat(currentLat.toFixed(4)),
+          parseFloat(currentLng.toFixed(4)),
+        )
+        setIsLoadingLocation(false)
+      },
+      (error) => {
+        console.error('Error getting location:', error)
+
+        let errorMessage = 'ไม่สามารถเข้าถึงตำแหน่งได้'
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            errorMessage = 'ผู้ใช้ปฏิเสธการเข้าถึงตำแหน่ง'
+            break
+          case error.POSITION_UNAVAILABLE:
+            errorMessage = 'ข้อมูลตำแหน่งไม่พร้อมใช้งาน'
+            break
+          case error.TIMEOUT:
+            errorMessage = 'หมดเวลาการค้นหาตำแหน่ง'
+            break
+        }
+
+        console.warn(
+          `Geolocation error: ${errorMessage}. Using Bangkok fallback.`,
+        )
+        setLocationError(errorMessage)
+
+        setLatitude(FALLBACK_LOCATION.lat)
+        setLongitude(FALLBACK_LOCATION.lng)
+        setCurrentLocationName(FALLBACK_LOCATION.address)
+        setAddress(FALLBACK_LOCATION.address)
+        setIsLoadingLocation(false)
+
+        onCoordinatesChange?.(
+          parseFloat(FALLBACK_LOCATION.lat.toFixed(4)),
+          parseFloat(FALLBACK_LOCATION.lng.toFixed(4)),
+        )
+        onAddressChange?.(FALLBACK_LOCATION.address)
+
+        setTimeout(() => setLocationError(null), 5000)
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000,
+      },
+    )
+  }, [initialCoordinates, initialAddress, onCoordinatesChange, onAddressChange])
+
+  useEffect(() => {
+    if (!mapRef.current || isMapInitializedRef.current || !currentCoordinates)
+      return
+
+    const timeoutId = setTimeout(() => {
+      if (!mapRef.current || isCleaningUpRef.current || !currentCoordinates)
+        return
+
+      try {
+        const map = L.map(mapRef.current, {
+          center: [currentCoordinates.lat, currentCoordinates.lng],
+          zoom: MAP_DEFAULT_ZOOM,
+          zoomControl: true,
+          scrollWheelZoom: true,
+          doubleClickZoom: false,
+          dragging: true,
+          touchZoom: true,
+          preferCanvas: true,
+        })
+
+        mapInstanceRef.current = map
+        isMapInitializedRef.current = true
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+          maxZoom: 19,
+          minZoom: 3,
+        }).addTo(map)
+
+        map.getContainer().style.cursor = 'grab'
+
+        const mapClickHandler = async (e: L.LeafletMouseEvent) => {
+          const container = map.getContainer()
+          const currentPinMode =
+            container.getAttribute('data-pin-mode') === 'true'
+
+          if (!currentPinMode) return
+
+          const now = Date.now()
+          if (now - lastPinClickRef.current < MAP_PIN_THROTTLE_MS) return
+          lastPinClickRef.current = now
+
+          const { lat, lng } = e.latlng
+
+          const roundedLat = parseFloat(lat.toFixed(4))
+          const roundedLng = parseFloat(lng.toFixed(4))
+
+          setLatitude(roundedLat)
+          setLongitude(roundedLng)
+
+          onCoordinatesChange?.(roundedLat, roundedLng)
+
+          debouncedReverseGeocode(roundedLat, roundedLng)
+
+          setIsPinMode(false)
+          container.style.cursor = 'grab'
+          container.removeAttribute('data-pin-mode')
+        }
+
+        map.on('click', mapClickHandler)
+
+        map.whenReady(() => {
+          map.invalidateSize()
+        })
+      } catch (error) {
+        console.error('Error initializing map:', error)
+      }
+    }, 50)
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [currentCoordinates, debouncedReverseGeocode, onCoordinatesChange])
+
+  useEffect(() => {
+    if (
+      !currentCoordinates ||
+      !mapInstanceRef.current ||
+      !isMapInitializedRef.current
+    )
+      return
+
+    const { lat, lng } = currentCoordinates
+
+    try {
+      const currentCenter = mapInstanceRef.current.getCenter()
+      const distance = currentCenter
+        ? currentCenter.distanceTo([lat, lng])
+        : Infinity
+
+      if (distance > 1000 || !currentCenter || !currentCenter.lat) {
+        mapInstanceRef.current.setView([lat, lng], MAP_DEFAULT_ZOOM, {
+          animate: true,
+        })
+      }
+
+      const displayText = address || currentLocationName
+      updateMarker(lat, lng, displayText)
+    } catch (error) {
+      console.error('Error updating map view:', error)
+      try {
+        mapInstanceRef.current.setView([lat, lng], MAP_DEFAULT_ZOOM, {
+          animate: false,
+        })
+        updateMarker(lat, lng, address || currentLocationName)
+      } catch (fallbackError) {
+        console.error('Fallback map update also failed:', fallbackError)
+      }
+    }
+  }, [currentCoordinates, address, currentLocationName, updateMarker])
+
+  useEffect(() => {
+    if (!mapInstanceRef.current) return
+
+    const container = mapInstanceRef.current.getContainer()
+    container.style.cursor = isPinMode ? 'crosshair' : 'grab'
+
+    if (isPinMode) {
+      container.setAttribute('data-pin-mode', 'true')
+    } else {
+      container.removeAttribute('data-pin-mode')
+    }
+  }, [isPinMode])
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
+      if (geocodeTimeoutRef.current) {
+        clearTimeout(geocodeTimeoutRef.current)
+      }
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+      }
+
+      cleanupMap()
+    }
+  }, [cleanupMap])
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        searchContainerRef.current &&
+        !searchContainerRef.current.contains(event.target as Node)
+      ) {
+        setShowSuggestions(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [])
+
+  const searchAddresses = useCallback(
+    async (addressText: string, abortController?: AbortController) => {
+      if (!addressText.trim() || addressText.length < 1) {
+        setSearchResults([])
+        setShowSuggestions(false)
+        return
+      }
+
+      setIsGeocodingLoading(true)
+      try {
+        const results = await searchAddressesService(addressText, {
+          signal: abortController?.signal,
+          limit: 5,
+        })
+
+        if (abortController?.signal.aborted) return
+
+        if (results.length > 0) {
+          setSearchResults(results)
+          setShowSuggestions(true)
+          setSelectedSuggestionIndex(-1)
+        } else {
+          setSearchResults([])
+          setShowSuggestions(false)
+          setSelectedSuggestionIndex(-1)
+        }
+      } catch (error: any) {
+        if (error.name !== 'AbortError') {
+          console.error('Search error:', error)
+          setSearchResults([])
+          setShowSuggestions(false)
+          setSelectedSuggestionIndex(-1)
+        }
+      } finally {
+        if (!abortController?.signal.aborted) {
+          setIsGeocodingLoading(false)
+        }
+      }
+    },
+    [],
+  )
+
+  const selectSearchResult = useCallback(
+    (result: MapSearchResult) => {
+      const roundedLat = parseFloat(result.lat.toFixed(4))
+      const roundedLng = parseFloat(result.lon.toFixed(4))
+
+      setShowSuggestions(false)
+      setSelectedSuggestionIndex(-1)
+
+      handleCoordinateChange(roundedLat, roundedLng, true)
+
+      setAddress(result.display_name)
+      setCurrentLocationName(result.display_name)
+      onAddressChange?.(result.display_name)
+
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.flyTo([roundedLat, roundedLng], MAP_DEFAULT_ZOOM, {
+          animate: true,
+          duration: 1.5,
+        })
+      }
+    },
+    [handleCoordinateChange, onAddressChange],
+  )
+
+  const geocodeAddress = useCallback(
+    async (addressText: string) => {
+      if (!addressText.trim()) return
+
+      setIsGeocodingLoading(true)
+      try {
+        const result = await geocodeAddressService(addressText)
+        if (result) {
+          selectSearchResult(result)
+        } else {
+          alert('ไม่พบที่อยู่ที่ระบุ กรุณาลองใหม่อีกครั้ง')
+        }
+      } catch (error) {
+        console.error('Geocoding error:', error)
+        alert('เกิดข้อผิดพลาดในการค้นหาที่อยู่')
+      } finally {
+        setIsGeocodingLoading(false)
+      }
+    },
+    [selectSearchResult],
+  )
+
+  const handleAddressSearch = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        if (
+          selectedSuggestionIndex >= 0 &&
+          searchResults[selectedSuggestionIndex]
+        ) {
+          selectSearchResult(searchResults[selectedSuggestionIndex])
+        } else {
+          geocodeAddress(address)
+        }
+        setShowSuggestions(false)
+        setSelectedSuggestionIndex(-1)
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        if (showSuggestions && searchResults.length > 0) {
+          setSelectedSuggestionIndex((prev) =>
+            prev < searchResults.length - 1 ? prev + 1 : 0,
+          )
+        }
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (showSuggestions && searchResults.length > 0) {
+          setSelectedSuggestionIndex((prev) =>
+            prev > 0 ? prev - 1 : searchResults.length - 1,
+          )
+        }
+      } else if (e.key === 'Escape') {
+        setShowSuggestions(false)
+        setSelectedSuggestionIndex(-1)
+      }
+    },
+    [
+      address,
+      geocodeAddress,
+      searchResults,
+      selectedSuggestionIndex,
+      selectSearchResult,
+      showSuggestions,
+    ],
+  )
+
+  const handleAddressChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setAddress(value)
+
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort()
+        abortControllerRef.current = null
+      }
+
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
+
+      if (value.length === 0) {
+        setSearchResults([])
+        setShowSuggestions(false)
+        setSelectedSuggestionIndex(-1)
+        setIsGeocodingLoading(false)
+        return
+      }
+
+      searchTimeoutRef.current = setTimeout(() => {
+        if (value.trim()) {
+          const newAbortController = new AbortController()
+          abortControllerRef.current = newAbortController
+          searchAddresses(value, newAbortController)
+        }
+      }, SEARCH_DEBOUNCE_MS)
+    },
+    [searchAddresses],
+  )
+
+  const handleAddressFocus = useCallback(() => {
+    if (searchResults.length > 0 && address.length >= 1) {
+      setShowSuggestions(true)
+    }
+  }, [searchResults, address])
+
+  const handleLatitudeChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      if (value === '') {
+        setLatitude(null)
+        return
+      }
+
+      const newLat = parseFloat(value)
+      if (!isNaN(newLat) && newLat >= -90 && newLat <= 90) {
+        const roundedLat = parseFloat(newLat.toFixed(4))
+        setLatitude(roundedLat)
+        if (longitude !== null) {
+          handleCoordinateChange(roundedLat, longitude)
+        }
+      }
+    },
+    [longitude, handleCoordinateChange],
+  )
+
+  const handleLongitudeChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      if (value === '') {
+        setLongitude(null)
+        return
+      }
+
+      const newLng = parseFloat(value)
+      if (!isNaN(newLng) && newLng >= -180 && newLng <= 180) {
+        const roundedLng = parseFloat(newLng.toFixed(4))
+        setLongitude(roundedLng)
+        if (latitude !== null) {
+          handleCoordinateChange(latitude, roundedLng)
+        }
+      }
+    },
+    [latitude, handleCoordinateChange],
+  )
+
+  const togglePinMode = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setIsPinMode((prev) => !prev)
+    },
+    [],
+  )
+
+  return {
+    address,
+    isGeocodingLoading,
+    showSuggestions,
+    searchResults,
+    selectedSuggestionIndex,
+    isLoadingLocation,
+    isPinMode,
+    locationError,
+    latitude,
+    longitude,
+    mapRef,
+    searchContainerRef,
+    handleAddressChange,
+    handleAddressSearch,
+    handleAddressFocus,
+    handleLatitudeChange,
+    handleLongitudeChange,
+    selectSearchResult,
+    togglePinMode,
+  }
+}

--- a/src/src/components/maps/map-client.tsx
+++ b/src/src/components/maps/map-client.tsx
@@ -12,29 +12,11 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useI18n } from '@/lib/i18n'
-import L from 'leaflet'
-import 'leaflet/dist/leaflet.css'
 import { Info, Loader2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import 'leaflet/dist/leaflet.css'
 
-interface MapClientProps {
-  width?: string
-  height?: string
-  onCoordinatesChange?: (lat: number, lng: number) => void
-  onAddressChange?: (address: string) => void
-  initialCoordinates?: { lat: number; lng: number }
-  initialAddress?: string
-}
-
-const defaultIcon = L.icon({
-  iconUrl: '/assets/images/icons/pinmaps.svg',
-  iconRetinaUrl: '/assets/images/icons/pinmaps.svg',
-  shadowUrl: '/assets/images/marker-shadow.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowSize: [41, 41],
-})
+import { useMapClient } from './hooks/use-map-client'
+import type { MapClientProps } from './types'
 
 export default function MapClient({
   width = 'w-full',
@@ -46,787 +28,35 @@ export default function MapClient({
 }: MapClientProps) {
   const { t } = useI18n()
 
-  // Refs
-  const mapRef = useRef<HTMLDivElement>(null)
-  const mapInstanceRef = useRef<L.Map | null>(null)
-  const markerRef = useRef<L.Marker | null>(null)
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const geocodeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  const searchContainerRef = useRef<HTMLDivElement>(null)
-  const abortControllerRef = useRef<AbortController | null>(null)
-  const isCleaningUpRef = useRef(false)
-  const isMapInitializedRef = useRef(false)
-  const lastGeocodedCoordsRef = useRef<string>('')
-
-  // State
-  const [latitude, setLatitude] = useState<number | null>(
-    initialCoordinates?.lat ?? null,
-  )
-  const [longitude, setLongitude] = useState<number | null>(
-    initialCoordinates?.lng ?? null,
-  )
-  const [address, setAddress] = useState<string>(initialAddress ?? '')
-  const [currentLocationName, setCurrentLocationName] =
-    useState<string>('ตำแหน่งปัจจุบัน')
-  const [isLoadingLocation, setIsLoadingLocation] = useState(true)
-  const [isGeocodingLoading, setIsGeocodingLoading] = useState(false)
-  const [searchResults, setSearchResults] = useState<
-    Array<{
-      display_name: string
-      lat: number
-      lon: number
-      type?: string
-      importance?: number
-      place_id?: string
-      addresstype?: string
-      class?: string
-      boundingbox?: string[]
-    }>
-  >([])
-  const [showSuggestions, setShowSuggestions] = useState(false)
-  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1)
-  const [isPinMode, setIsPinMode] = useState(false)
-  const [locationError, setLocationError] = useState<string | null>(null)
-
-  // Memoized coordinates to prevent unnecessary re-renders
-  const currentCoordinates = useMemo(() => {
-    if (latitude === null || longitude === null) return null
-    return { lat: latitude, lng: longitude }
-  }, [latitude, longitude])
-
-  // Safe cleanup function
-  const cleanupMap = useCallback(() => {
-    if (isCleaningUpRef.current) return
-    isCleaningUpRef.current = true
-
-    try {
-      if (markerRef.current) {
-        markerRef.current = null
-      }
-
-      if (mapInstanceRef.current) {
-        mapInstanceRef.current.off()
-        mapInstanceRef.current.remove()
-        mapInstanceRef.current = null
-      }
-
-      isMapInitializedRef.current = false
-    } catch (error) {
-      console.error('Error during map cleanup:', error)
-    } finally {
-      isCleaningUpRef.current = false
-    }
-  }, [])
-
-  // Optimized marker update function
-  const updateMarker = useCallback(
-    (lat: number, lng: number, popupText: string) => {
-      if (!mapInstanceRef.current) return
-
-      try {
-        // Remove existing marker
-        if (
-          markerRef.current &&
-          mapInstanceRef.current.hasLayer(markerRef.current)
-        ) {
-          mapInstanceRef.current.removeLayer(markerRef.current)
-        }
-
-        // Add new marker with animation
-        const newMarker = L.marker([lat, lng], {
-          icon: defaultIcon,
-          riseOnHover: true,
-        }).addTo(mapInstanceRef.current)
-
-        markerRef.current = newMarker
-        newMarker.bindPopup(popupText)
-
-        // Show popup briefly for feedback
-        newMarker.openPopup()
-        setTimeout(() => {
-          if (
-            newMarker &&
-            mapInstanceRef.current &&
-            mapInstanceRef.current.hasLayer(newMarker)
-          ) {
-            newMarker.closePopup()
-          }
-        }, 2000)
-      } catch (error) {
-        console.error('Error updating marker:', error)
-      }
-    },
-    [],
-  )
-
-  // Debounced reverse geocoding with caching
-  const debouncedReverseGeocode = useCallback(
-    async (lat: number, lng: number) => {
-      const coordKey = `${lat.toFixed(4)},${lng.toFixed(4)}`
-
-      // Skip if same coordinates as last geocoded
-      if (lastGeocodedCoordsRef.current === coordKey) return
-
-      // Clear existing timeout
-      if (geocodeTimeoutRef.current) {
-        clearTimeout(geocodeTimeoutRef.current)
-      }
-
-      geocodeTimeoutRef.current = setTimeout(async () => {
-        try {
-          setIsGeocodingLoading(true)
-          lastGeocodedCoordsRef.current = coordKey
-
-          const response = await fetch(
-            `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=14&addressdetails=1`,
-          )
-          const data = await response.json()
-
-          if (data && data.display_name) {
-            setCurrentLocationName(data.display_name)
-            setAddress(data.display_name)
-            onAddressChange?.(data.display_name)
-
-            // Update marker popup
-            updateMarker(lat, lng, data.display_name)
-          } else {
-            const fallbackName = 'ตำแหน่งที่ระบุ'
-            setCurrentLocationName(fallbackName)
-            setAddress(fallbackName)
-            onAddressChange?.(fallbackName)
-
-            updateMarker(lat, lng, fallbackName)
-          }
-        } catch (error) {
-          console.error('Reverse geocoding error:', error)
-          const fallbackName = 'ตำแหน่งที่ระบุ'
-          setCurrentLocationName(fallbackName)
-          setAddress(fallbackName)
-          onAddressChange?.(fallbackName)
-
-          updateMarker(lat, lng, fallbackName)
-        } finally {
-          setIsGeocodingLoading(false)
-        }
-      }, 300) // 300ms debounce for real-time feel
-    },
-    [onAddressChange, updateMarker],
-  )
-
-  // Optimized coordinate change handler
-  const handleCoordinateChange = useCallback(
-    async (lat: number, lng: number, skipGeocode = false) => {
-      const roundedLat = parseFloat(lat.toFixed(4))
-      const roundedLng = parseFloat(lng.toFixed(4))
-
-      // Update coordinates immediately for real-time feedback
-      setLatitude(roundedLat)
-      setLongitude(roundedLng)
-
-      // Call parent callbacks immediately
-      onCoordinatesChange?.(roundedLat, roundedLng)
-
-      // Update map view if needed
-      if (mapInstanceRef.current) {
-        const currentCenter = mapInstanceRef.current.getCenter()
-        const distance = currentCenter.distanceTo([roundedLat, roundedLng])
-
-        // Only pan if significant movement (> 100m) to avoid jittery movement
-        if (distance > 100) {
-          mapInstanceRef.current.panTo([roundedLat, roundedLng], {
-            animate: true,
-            duration: 0.5,
-          })
-        }
-      }
-
-      // Debounced reverse geocoding
-      if (!skipGeocode) {
-        debouncedReverseGeocode(roundedLat, roundedLng)
-      }
-    },
-    [onCoordinatesChange, debouncedReverseGeocode],
-  )
-
-  // Get current location on component mount
-  useEffect(() => {
-    // If initial coordinates provided, use them instead of geolocation
-    if (
-      initialCoordinates &&
-      initialCoordinates.lat !== 0 &&
-      initialCoordinates.lng !== 0
-    ) {
-      setLatitude(initialCoordinates.lat)
-      setLongitude(initialCoordinates.lng)
-      if (initialAddress) {
-        setAddress(initialAddress)
-        setCurrentLocationName(initialAddress)
-      }
-      setIsLoadingLocation(false)
-      return
-    }
-
-    if (!navigator.geolocation) {
-      const errorMsg = 'เบราว์เซอร์ไม่รองรับการหาตำแหน่ง'
-      console.error('Geolocation is not supported by this browser.')
-      setLocationError(errorMsg)
-
-      // Fallback to Bangkok coordinates
-      const fallbackLat = 13.7563
-      const fallbackLng = 100.5018
-      const fallbackAddress = 'กรุงเทพมหานคร (ตำแหน่งเริ่มต้น)'
-
-      setLatitude(fallbackLat)
-      setLongitude(fallbackLng)
-      setCurrentLocationName(fallbackAddress)
-      setAddress(fallbackAddress)
-      setIsLoadingLocation(false)
-
-      // Call callbacks with fallback coordinates
-      onCoordinatesChange?.(
-        parseFloat(fallbackLat.toFixed(4)),
-        parseFloat(fallbackLng.toFixed(4)),
-      )
-      onAddressChange?.(fallbackAddress)
-
-      // Clear error after 5 seconds
-      setTimeout(() => setLocationError(null), 5000)
-      return
-    }
-
-    navigator.geolocation.getCurrentPosition(
-      async (position) => {
-        const { latitude: currentLat, longitude: currentLng } = position.coords
-        setLatitude(currentLat)
-        setLongitude(currentLng)
-
-        // Get location name from coordinates
-        try {
-          const response = await fetch(
-            `https://nominatim.openstreetmap.org/reverse?format=json&lat=${currentLat}&lon=${currentLng}&zoom=14&addressdetails=1`,
-          )
-          const data = await response.json()
-          if (data && data.display_name) {
-            setCurrentLocationName(data.display_name)
-            setAddress(data.display_name)
-            onAddressChange?.(data.display_name)
-          } else {
-            const fallbackName = 'ตำแหน่งปัจจุบัน'
-            setCurrentLocationName(fallbackName)
-            setAddress(fallbackName)
-            onAddressChange?.(fallbackName)
-          }
-        } catch (error) {
-          console.error('Reverse geocoding error:', error)
-          const fallbackName = 'ตำแหน่งปัจจุบัน'
-          setCurrentLocationName(fallbackName)
-          setAddress(fallbackName)
-          onAddressChange?.(fallbackName)
-        }
-
-        // Call coordinates callback
-        onCoordinatesChange?.(
-          parseFloat(currentLat.toFixed(4)),
-          parseFloat(currentLng.toFixed(4)),
-        )
-        setIsLoadingLocation(false)
-      },
-      (error) => {
-        console.error('Error getting location:', error)
-
-        let errorMessage = 'ไม่สามารถเข้าถึงตำแหน่งได้'
-        switch (error.code) {
-          case error.PERMISSION_DENIED:
-            errorMessage = 'ผู้ใช้ปฏิเสธการเข้าถึงตำแหน่ง'
-            break
-          case error.POSITION_UNAVAILABLE:
-            errorMessage = 'ข้อมูลตำแหน่งไม่พร้อมใช้งาน'
-            break
-          case error.TIMEOUT:
-            errorMessage = 'หมดเวลาการค้นหาตำแหน่ง'
-            break
-        }
-
-        console.warn(
-          `Geolocation error: ${errorMessage}. Using Bangkok fallback.`,
-        )
-        setLocationError(errorMessage)
-
-        // Fallback to Bangkok coordinates if location access fails
-        const fallbackLat = 13.7563
-        const fallbackLng = 100.5018
-        const fallbackAddress = 'กรุงเทพมหานคร (ตำแหน่งเริ่มต้น)'
-
-        setLatitude(fallbackLat)
-        setLongitude(fallbackLng)
-        setCurrentLocationName(fallbackAddress)
-        setAddress(fallbackAddress)
-        setIsLoadingLocation(false)
-
-        // Call callbacks with fallback coordinates
-        onCoordinatesChange?.(
-          parseFloat(fallbackLat.toFixed(4)),
-          parseFloat(fallbackLng.toFixed(4)),
-        )
-        onAddressChange?.(fallbackAddress)
-
-        // Clear error after 5 seconds
-        setTimeout(() => setLocationError(null), 5000)
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 60000,
-      },
-    )
-  }, [initialCoordinates, initialAddress, onCoordinatesChange, onAddressChange])
-
-  // Initialize map once and update content
-  useEffect(() => {
-    if (!mapRef.current || isMapInitializedRef.current || !currentCoordinates)
-      return
-
-    const timeoutId = setTimeout(() => {
-      if (!mapRef.current || isCleaningUpRef.current || !currentCoordinates)
-        return
-
-      try {
-        // Create map instance once with valid coordinates
-        const map = L.map(mapRef.current, {
-          center: [currentCoordinates.lat, currentCoordinates.lng],
-          zoom: 15,
-          zoomControl: true,
-          scrollWheelZoom: true,
-          doubleClickZoom: false,
-          dragging: true,
-          touchZoom: true,
-          preferCanvas: true, // Better performance
-        })
-
-        mapInstanceRef.current = map
-        isMapInitializedRef.current = true
-
-        // Add tile layer
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          attribution:
-            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-          maxZoom: 19,
-          minZoom: 3,
-        }).addTo(map)
-
-        // Set default cursor
-        map.getContainer().style.cursor = 'grab'
-
-        // Handle map clicks for pin mode with improved state handling
-        let lastClickTime = 0
-        const mapClickHandler = async (e: L.LeafletMouseEvent) => {
-          // Check current pin mode from DOM attribute to avoid stale closure
-          const container = map.getContainer()
-          const currentPinMode =
-            container.getAttribute('data-pin-mode') === 'true'
-
-          if (!currentPinMode) return
-
-          const now = Date.now()
-          if (now - lastClickTime < 300) return // Throttle clicks
-          lastClickTime = now
-
-          const { lat, lng } = e.latlng
-
-          // Update coordinates immediately
-          const roundedLat = parseFloat(lat.toFixed(4))
-          const roundedLng = parseFloat(lng.toFixed(4))
-
-          setLatitude(roundedLat)
-          setLongitude(roundedLng)
-
-          // Call handlers
-          onCoordinatesChange?.(roundedLat, roundedLng)
-
-          // Start reverse geocoding
-          debouncedReverseGeocode(roundedLat, roundedLng)
-
-          // Exit pin mode after successful pin
-          setIsPinMode(false)
-          container.style.cursor = 'grab'
-          container.removeAttribute('data-pin-mode')
-        }
-
-        map.on('click', mapClickHandler)
-
-        // Handle map ready
-        map.whenReady(() => {
-          map.invalidateSize()
-        })
-      } catch (error) {
-        console.error('Error initializing map:', error)
-      }
-    }, 50)
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [currentCoordinates]) // Depend on coordinates to ensure map waits for valid location
-
-  // Update map view and marker when coordinates change
-  useEffect(() => {
-    if (
-      !currentCoordinates ||
-      !mapInstanceRef.current ||
-      !isMapInitializedRef.current
-    )
-      return
-
-    const { lat, lng } = currentCoordinates
-
-    try {
-      // Set view if first time or significant movement
-      const currentCenter = mapInstanceRef.current.getCenter()
-      const distance = currentCenter
-        ? currentCenter.distanceTo([lat, lng])
-        : Infinity
-
-      if (distance > 1000 || !currentCenter || !currentCenter.lat) {
-        // Initial load or major change
-        mapInstanceRef.current.setView([lat, lng], 15, { animate: true })
-      }
-
-      // Update marker
-      const displayText = address || currentLocationName
-      updateMarker(lat, lng, displayText)
-    } catch (error) {
-      console.error('Error updating map view:', error)
-      // Fallback: try to set view without animation
-      try {
-        mapInstanceRef.current.setView([lat, lng], 15, { animate: false })
-        updateMarker(lat, lng, address || currentLocationName)
-      } catch (fallbackError) {
-        console.error('Fallback map update also failed:', fallbackError)
-      }
-    }
-  }, [currentCoordinates, address, currentLocationName, updateMarker])
-
-  // Handle pin mode cursor change with DOM attribute sync
-  useEffect(() => {
-    if (!mapInstanceRef.current) return
-
-    const container = mapInstanceRef.current.getContainer()
-    container.style.cursor = isPinMode ? 'crosshair' : 'grab'
-
-    // Set DOM attribute for click handler reference
-    if (isPinMode) {
-      container.setAttribute('data-pin-mode', 'true')
-    } else {
-      container.removeAttribute('data-pin-mode')
-    }
-  }, [isPinMode])
-
-  // Cleanup on component unmount
-  useEffect(() => {
-    return () => {
-      // Clear any pending search timeouts
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current)
-      }
-      if (geocodeTimeoutRef.current) {
-        clearTimeout(geocodeTimeoutRef.current)
-      }
-
-      // Cancel any pending requests
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-      }
-
-      cleanupMap()
-    }
-  }, [cleanupMap])
-
-  // Handle click outside to close suggestions
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        searchContainerRef.current &&
-        !searchContainerRef.current.contains(event.target as Node)
-      ) {
-        setShowSuggestions(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  }, [])
-
-  // Optimized search with request cancellation and instant search
-  const searchAddresses = useCallback(
-    async (addressText: string, abortController?: AbortController) => {
-      if (!addressText.trim() || addressText.length < 1) {
-        setSearchResults([])
-        setShowSuggestions(false)
-        return
-      }
-
-      setIsGeocodingLoading(true)
-      try {
-        const response = await fetch(
-          `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
-            addressText,
-          )}&limit=5&addressdetails=1`,
-          { signal: abortController?.signal },
-        )
-
-        if (abortController?.signal.aborted) return
-
-        const data = await response.json()
-
-        // Check again after async operation
-        if (abortController?.signal.aborted) return
-
-        if (data && data.length > 0) {
-          const results = data.map(
-            (result: {
-              lat: string
-              lon: string
-              display_name: string
-              type?: string
-              importance?: number
-              place_id?: string
-              addresstype?: string
-              class?: string
-              boundingbox?: string[]
-            }) => {
-              const {
-                lat,
-                lon,
-                display_name,
-                type,
-                importance,
-                place_id,
-                addresstype,
-                class: placeClass,
-                boundingbox,
-              } = result
-
-              return {
-                display_name,
-                lat: parseFloat(lat),
-                lon: parseFloat(lon),
-                type,
-                importance,
-                place_id,
-                addresstype,
-                class: placeClass,
-                boundingbox,
-              }
-            },
-          )
-          setSearchResults(results)
-          setShowSuggestions(true)
-          setSelectedSuggestionIndex(-1)
-        } else {
-          setSearchResults([])
-          setShowSuggestions(false)
-          setSelectedSuggestionIndex(-1)
-        }
-      } catch (error: any) {
-        if (error.name !== 'AbortError') {
-          console.error('Search error:', error)
-          setSearchResults([])
-          setShowSuggestions(false)
-          setSelectedSuggestionIndex(-1)
-        }
-      } finally {
-        if (!abortController?.signal.aborted) {
-          setIsGeocodingLoading(false)
-        }
-      }
-    },
-    [],
-  )
-
-  // Select a search result with smooth animation
-  const selectSearchResult = useCallback(
-    (result: (typeof searchResults)[0]) => {
-      const roundedLat = parseFloat(result.lat.toFixed(4))
-      const roundedLng = parseFloat(result.lon.toFixed(4))
-
-      // Update state immediately for responsive UI
-      setShowSuggestions(false)
-      setSelectedSuggestionIndex(-1)
-
-      // Call coordinate change handler with skip geocode flag (we already have the address)
-      handleCoordinateChange(roundedLat, roundedLng, true)
-
-      // Update address immediately
-      setAddress(result.display_name)
-      setCurrentLocationName(result.display_name)
-      onAddressChange?.(result.display_name)
-
-      // Smooth map animation to new location
-      if (mapInstanceRef.current) {
-        mapInstanceRef.current.flyTo([roundedLat, roundedLng], 15, {
-          animate: true,
-          duration: 1.5,
-        })
-      }
-    },
-    [handleCoordinateChange, onAddressChange],
-  )
-
-  // Optimized geocoding function
-  const geocodeAddress = useCallback(
-    async (addressText: string) => {
-      if (!addressText.trim()) return
-
-      setIsGeocodingLoading(true)
-      try {
-        const response = await fetch(
-          `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(
-            addressText,
-          )}&limit=1`,
-        )
-        const data = await response.json()
-        if (data && data.length > 0) {
-          const result = data[0]
-          selectSearchResult({
-            display_name: result.display_name,
-            lat: parseFloat(result.lat),
-            lon: parseFloat(result.lon),
-            type: result.type,
-            importance: result.importance,
-            place_id: result.place_id,
-            addresstype: result.addresstype,
-            class: result.class,
-            boundingbox: result.boundingbox,
-          })
-        } else {
-          alert('ไม่พบที่อยู่ที่ระบุ กรุณาลองใหม่อีกครั้ง')
-        }
-      } catch (error) {
-        console.error('Geocoding error:', error)
-        alert('เกิดข้อผิดพลาดในการค้นหาที่อยู่')
-      } finally {
-        setIsGeocodingLoading(false)
-      }
-    },
-    [selectSearchResult],
-  )
-
-  // Handle address search with keyboard navigation
-  const handleAddressSearch = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      if (
-        selectedSuggestionIndex >= 0 &&
-        searchResults[selectedSuggestionIndex]
-      ) {
-        selectSearchResult(searchResults[selectedSuggestionIndex])
-      } else {
-        geocodeAddress(address)
-      }
-      setShowSuggestions(false)
-      setSelectedSuggestionIndex(-1)
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      if (showSuggestions && searchResults.length > 0) {
-        setSelectedSuggestionIndex((prev) =>
-          prev < searchResults.length - 1 ? prev + 1 : 0,
-        )
-      }
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      if (showSuggestions && searchResults.length > 0) {
-        setSelectedSuggestionIndex((prev) =>
-          prev > 0 ? prev - 1 : searchResults.length - 1,
-        )
-      }
-    } else if (e.key === 'Escape') {
-      setShowSuggestions(false)
-      setSelectedSuggestionIndex(-1)
-    }
-  }
-
-  // Handle address input change with proper request cancellation
-  const handleAddressChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      setAddress(value)
-
-      // Cancel previous request
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort()
-        abortControllerRef.current = null
-      }
-
-      // Clear previous timeout
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current)
-      }
-
-      // Clear suggestions immediately if input is empty
-      if (value.length === 0) {
-        setSearchResults([])
-        setShowSuggestions(false)
-        setSelectedSuggestionIndex(-1)
-        setIsGeocodingLoading(false)
-        return
-      }
-
-      // Start searching from first character with very short debounce
-      searchTimeoutRef.current = setTimeout(() => {
-        if (value.trim()) {
-          // Create new abort controller for this request
-          const newAbortController = new AbortController()
-          abortControllerRef.current = newAbortController
-          searchAddresses(value, newAbortController)
-        }
-      }, 150) // Reduced to 150ms for almost instant search
-    },
-    [searchAddresses],
-  )
-
-  // Optimized coordinate input handlers with real-time updates
-  const handleLatitudeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      if (value === '') {
-        setLatitude(null)
-        return
-      }
-
-      const newLat = parseFloat(value)
-      if (!isNaN(newLat) && newLat >= -90 && newLat <= 90) {
-        setLatitude(parseFloat(newLat.toFixed(4)))
-        if (longitude !== null) {
-          handleCoordinateChange(parseFloat(newLat.toFixed(4)), longitude)
-        }
-      }
-    },
-    [longitude, handleCoordinateChange],
-  )
-
-  const handleLongitudeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      if (value === '') {
-        setLongitude(null)
-        return
-      }
-
-      const newLng = parseFloat(value)
-      if (!isNaN(newLng) && newLng >= -180 && newLng <= 180) {
-        setLongitude(parseFloat(newLng.toFixed(4)))
-        if (latitude !== null) {
-          handleCoordinateChange(latitude, parseFloat(newLng.toFixed(4)))
-        }
-      }
-    },
-    [latitude, handleCoordinateChange],
-  )
+  const {
+    address,
+    isGeocodingLoading,
+    showSuggestions,
+    searchResults,
+    selectedSuggestionIndex,
+    isLoadingLocation,
+    isPinMode,
+    locationError,
+    latitude,
+    longitude,
+    mapRef,
+    searchContainerRef,
+    handleAddressChange,
+    handleAddressSearch,
+    handleAddressFocus,
+    handleLatitudeChange,
+    handleLongitudeChange,
+    selectSearchResult,
+    togglePinMode,
+  } = useMapClient({
+    onCoordinatesChange,
+    onAddressChange,
+    initialCoordinates,
+    initialAddress,
+  })
 
   return (
     <div className="space-y-6">
-      {/* Location Error Notification */}
       {locationError && (
         <Alert className="border-amber-300 bg-amber-50">
           <Info className="h-4 w-4 text-amber-600" />
@@ -835,8 +65,6 @@ export default function MapClient({
           </AlertDescription>
         </Alert>
       )}
-
-      {/* Address Search Section */}
 
       <div className="relative space-y-4">
         <div className="space-y-2">
@@ -850,25 +78,17 @@ export default function MapClient({
               value={address}
               onChange={handleAddressChange}
               onKeyDown={handleAddressSearch}
-              onFocus={() => {
-                // Show existing suggestions on focus from first character
-                if (searchResults.length > 0 && address.length >= 1) {
-                  setShowSuggestions(true)
-                }
-              }}
+              onFocus={handleAddressFocus}
               placeholder={t('charging-stations.address_placeholder')}
-              disabled={false} // Never disable input field
               className="h-10 w-full border-none bg-[#f2f2f2] pr-10 transition-all duration-200 sm:h-11"
             />
 
-            {/* Loading indicator inside input */}
             {isGeocodingLoading && (
               <div className="absolute right-3 top-1/2 -translate-y-1/2">
                 <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
               </div>
             )}
 
-            {/* Search Suggestions Dropdown */}
             {showSuggestions && searchResults.length > 0 && (
               <Card className="z-9999 absolute left-0 right-0 top-full mt-1 max-h-60 overflow-hidden shadow-xl">
                 <div className="max-h-60 overflow-y-auto">
@@ -903,13 +123,11 @@ export default function MapClient({
           </div>
         </div>
 
-        {/* Spacer to prevent overlap when dropdown is open */}
         {showSuggestions && searchResults.length > 0 && (
           <div className="h-20"></div>
         )}
       </div>
 
-      {/* Map container */}
       <div className="relative">
         <div ref={mapRef} className={`${width} ${height} rounded-lg border`}>
           {isLoadingLocation && (
@@ -926,21 +144,16 @@ export default function MapClient({
           )}
         </div>
 
-        {/* Pin on map button - positioned at top right */}
         {!isLoadingLocation && (
           <div className="z-1000 absolute right-3 top-3">
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      setIsPinMode(!isPinMode)
-                    }}
-                    variant={isPinMode ? 'default' : 'default'}
+                    onClick={togglePinMode}
+                    variant="default"
                     size="sm"
-                    className={`rounded-lg ${isPinMode ? '' : ''}`}
+                    className="rounded-lg"
                   >
                     {isPinMode ? '📍 Pin Mode ON' : '📍 Pin on map'}
                   </Button>
@@ -957,7 +170,6 @@ export default function MapClient({
           </div>
         )}
 
-        {/* Pin mode instruction with smooth animation */}
         {isPinMode && !isLoadingLocation && (
           <div className="z-1000 absolute right-3 top-16 max-w-xs duration-300 animate-in slide-in-from-top-2">
             <Alert className="border-green-300 bg-green-50 shadow-lg">
@@ -969,7 +181,6 @@ export default function MapClient({
           </div>
         )}
       </div>
-      {/* Input fields for coordinates */}
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className="space-y-2">

--- a/src/src/components/maps/services/nominatim-service.ts
+++ b/src/src/components/maps/services/nominatim-service.ts
@@ -1,0 +1,88 @@
+import type { MapSearchResult } from '../types'
+
+const NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org'
+
+const toSearchResult = (entry: any): MapSearchResult => ({
+  display_name: entry.display_name,
+  lat: parseFloat(entry.lat),
+  lon: parseFloat(entry.lon),
+  type: entry.type,
+  importance: entry.importance,
+  place_id: entry.place_id,
+  addresstype: entry.addresstype,
+  class: entry.class,
+  boundingbox: entry.boundingbox,
+})
+
+const buildUrl = (path: string, params: Record<string, string>) => {
+  const url = new URL(`${NOMINATIM_BASE_URL}/${path}`)
+
+  Object.entries(params).forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+
+  return url.toString()
+}
+
+export interface SearchAddressOptions {
+  signal?: AbortSignal
+  limit?: number
+}
+
+export async function searchAddresses(
+  query: string,
+  options: SearchAddressOptions = {},
+): Promise<MapSearchResult[]> {
+  const { signal, limit = 5 } = options
+
+  const url = buildUrl('search', {
+    format: 'json',
+    q: query,
+    limit: String(limit),
+    addressdetails: '1',
+  })
+
+  const response = await fetch(url, { signal })
+
+  if (!response.ok) {
+    throw new Error(`Search request failed with status ${response.status}`)
+  }
+
+  const payload = await response.json()
+
+  if (!Array.isArray(payload)) {
+    return []
+  }
+
+  return payload.map(toSearchResult)
+}
+
+export async function geocodeAddress(
+  address: string,
+): Promise<MapSearchResult | null> {
+  const results = await searchAddresses(address, { limit: 1 })
+  return results[0] ?? null
+}
+
+export async function reverseGeocode(
+  latitude: number,
+  longitude: number,
+): Promise<string | null> {
+  const url = buildUrl('reverse', {
+    format: 'json',
+    lat: latitude.toString(),
+    lon: longitude.toString(),
+    zoom: '14',
+    addressdetails: '1',
+  })
+
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error(`Reverse geocoding failed with status ${response.status}`)
+  }
+
+  const payload = await response.json()
+
+  return payload?.display_name ?? null
+}

--- a/src/src/components/maps/types.ts
+++ b/src/src/components/maps/types.ts
@@ -1,0 +1,25 @@
+export interface MapCoordinates {
+  lat: number
+  lng: number
+}
+
+export interface MapClientProps {
+  width?: string
+  height?: string
+  onCoordinatesChange?: (lat: number, lng: number) => void
+  onAddressChange?: (address: string) => void
+  initialCoordinates?: MapCoordinates
+  initialAddress?: string
+}
+
+export interface MapSearchResult {
+  display_name: string
+  lat: number
+  lon: number
+  type?: string
+  importance?: number
+  place_id?: string
+  addresstype?: string
+  class?: string
+  boundingbox?: string[]
+}


### PR DESCRIPTION
## Summary
- extract the map interaction, geolocation, and search handling into a dedicated `useMapClient` hook
- add a Nominatim service module plus shared types to keep data fetching separated from UI concerns
- update the `MapClient` component to consume the hook so the file now focuses on rendering only

## Testing
- pnpm lint *(fails: Next.js lint command cannot locate the app directory in this multi-root layout)*
- (in src) pnpm lint *(fails: existing lint issues unrelated to this change block the run)*

------
https://chatgpt.com/codex/tasks/task_e_68cde42f5ea4832e8d46856578159ca3