### PR TITLE
refactor: extract charging station page services

### DIFF
--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_components/charging-stations-page.tsx
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_components/charging-stations-page.tsx
@@ -1,49 +1,26 @@
 'use client'
+
 import {
   AddChargingStationDialog,
   ChargingStationsTable,
   EditsChargingStationDialog,
-  convertStationDetailToFormData,
-  fetchChargingStationDetail,
   type ChargingStation,
 } from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations'
 import { TeamHeader } from '@/app/[locale]/(back-office)/team/_components/team-header'
-import { Button } from '@/components/ui/button'
-import {
-  type ChargingStationFormData,
-  type CreateChargingStationRequest,
-  type ExtendedUpdateChargingStationRequest,
-  type WorkTime,
-} from '../_schemas/charging-stations.schema'
-
-// ============================
-// Types & Interfaces
-// ============================
-
-interface ChargingStationFormWithWork extends ChargingStationFormData {
-  work?: WorkTime[]
-  // refactor later
-  images?: globalThis.File[] // รูปใหม่ที่จะอัพโหลด
-  deletedImageIds?: number[] // ID ของรูปที่จะลบ
-}
-
+import { TeamTabMenu } from '@/app/[locale]/(back-office)/team/_components/team-tab-menu'
 import { DeleteConfirmDialog, SuccessDialog } from '@/components/notifications'
+import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
-
-import { TeamTabMenu } from '@/app/[locale]/(back-office)/team/_components/team-tab-menu'
-import { useI18n } from '@/lib/i18n'
-import { getPartnerIdFromStorage } from '@/lib/utils/user-storage'
-import { ChevronDown, Plus, Search } from 'lucide-react'
-import { useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
+import { useChargingStationsPage } from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks'
+import { type ChargingStationFormWithWork } from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services'
 import {
-  useChargingStations,
-  useCreateChargingStation,
-  useDeleteChargingStation,
-  useUpdateChargingStation,
-} from '../_hooks/use-charging-stations'
+  type CreateChargingStationRequest,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_schemas'
+import { useI18n } from '@/lib/i18n'
+import { ChevronDown, Plus, Search } from 'lucide-react'
+import { useParams } from 'next/navigation'
+import { toast } from 'sonner'
 
 interface ChargingStationsPageProps {
   teamId: string
@@ -51,265 +28,77 @@ interface ChargingStationsPageProps {
 
 export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
   const { t } = useI18n()
-  const router = useRouter()
-  const searchParams = useSearchParams()
   const params = useParams()
+  const teamGroupId = Number.parseInt(teamId, 10)
 
-  const [currentPage, setCurrentPage] = useState(() => {
-    const pageParam = searchParams.get('page')
-    return pageParam ? parseInt(pageParam, 10) : 1
-  })
+  const { pagination, search, dialogs, selection, data, status, actions } =
+    useChargingStationsPage({ teamId })
 
-  const [pageSize, setPageSize] = useState(() => {
-    const pageSizeParam = searchParams.get('pageSize')
-    return pageSizeParam ? parseInt(pageSizeParam, 10) : 10
-  })
+  const tableError = data.error instanceof Error ? data.error : null
 
-  const [searchQuery, setSearchQuery] = useState(() => {
-    return searchParams.get('search') || ''
-  })
-
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
-  const [selectedStation, setSelectedStation] = useState<ChargingStationFormData | null>(null)
-  const [selectedStationId, setSelectedStationId] = useState<string | number | null>(null)
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [stationToDelete, setStationToDelete] = useState<ChargingStation | null>(null)
-  const [showEditSuccessDialog, setShowEditSuccessDialog] = useState(false)
-
-  const teamGroupId = parseInt(teamId, 10)
-
-  const createStationMutation = useCreateChargingStation()
-  const deleteMutation = useDeleteChargingStation()
-  const updateStation = useUpdateChargingStation()
-
-  const updateURL = useCallback(
-    (page: number, size: number, search: string) => {
-      const params = new URLSearchParams()
-      params.set('page', page.toString())
-      params.set('pageSize', size.toString())
-      if (search.trim()) {
-        params.set('search', search)
-      }
-
-      const currentPath = window.location.pathname
-      const newUrl = `${currentPath}?${params.toString()}`
-
-      window.history.replaceState({}, '', newUrl)
-
-      router.replace(newUrl, { scroll: false })
-    },
-    [router],
-  )
-
-  useEffect(() => {
-    updateURL(currentPage, pageSize, searchQuery)
-  }, [currentPage, pageSize, searchQuery, updateURL])
-
-  // Fetch charging stations data
-  const apiParams = useMemo(
-    () => ({
-      team_group_id: teamGroupId,
-      page: currentPage,
-      pageSize: pageSize,
-      search: searchQuery || undefined,
-    }),
-    [teamGroupId, currentPage, pageSize, searchQuery],
-  )
-
-  const { data: stationsResponse, isLoading, error } = useChargingStations(apiParams)
-
-  useEffect(() => {
-    console.log('Charging stations query status:', {
-      isLoading,
-      error,
-    })
-    if (stationsResponse) {
-      console.log('Charging stations response:', stationsResponse)
-      console.log('Charging stations data:', stationsResponse.data?.data)
-    }
-  }, [stationsResponse, isLoading, error])
-
-  const chargingStations = stationsResponse?.data?.data || []
-  const totalItems = stationsResponse?.data?.item_total || 0
-  const totalPages = stationsResponse?.data?.page_total || 1
-
-  const handleAddStation = async (data: CreateChargingStationRequest) => {
-    const partnerId = getPartnerIdFromStorage()
-
-    if (!partnerId) {
-      console.error('Partner ID not found in localStorage')
-      const error = new Error('Partner ID not found. Please log in again.')
-      throw error
-    }
-
+  const handleAddStation = async (payload: CreateChargingStationRequest) => {
     try {
-      await createStationMutation.mutateAsync(data)
-      // Close the dialog
-      setIsDialogOpen(false)
+      await actions.addStation(payload)
     } catch (error) {
-      console.error('Error creating charging station:', error)
-      // ไม่ใช้ toast.error ที่นี่แล้ว ให้ dialog จัดการเอง
-      // Re-throw error เพื่อให้ dialog สามารถจับได้
       throw error
     }
-  }
-
-  const handleShowEditSuccessDialog = () => {
-    setShowEditSuccessDialog(true)
-  }
-
-  const handleEditSuccessDialogClose = () => {
-    setShowEditSuccessDialog(false)
-    setSelectedStation(null)
-    setSelectedStationId(null)
-    setIsEditDialogOpen(false)
   }
 
   const handleEditStation = async (station: ChargingStation) => {
-    const res = await fetchChargingStationDetail(station.id)
-    const apiData = Array.isArray(res.data) ? res.data[0] : res.data
-
-    // Use the proper conversion function instead of manual mapping
-    const convertedData = convertStationDetailToFormData(apiData)
-
-    // Extract the form data part (excluding existingGallery)
-    const { existingGallery, ...formData } = convertedData
-
-    // Store the form data and pass existingGallery to the dialog separately
-    setSelectedStation({
-      ...formData,
-      // Add existingGallery as a separate property for the dialog to use
-      existingGallery,
-    } as ChargingStationFormData & { existingGallery: any[] })
-    setSelectedStationId(apiData.id)
-    setIsEditDialogOpen(true)
-  }
-
-  const handleUpdateStation = async (data: ChargingStationFormWithWork) => {
-    return new Promise<void>((resolve, reject) => {
-      try {
-        const partnerId = getPartnerIdFromStorage()
-
-        // ใช้ work array ที่ส่งมาจาก dialog
-        const work: WorkTime[] = data.work ?? []
-
-        updateStation.mutate(
-          {
-            stationId: selectedStationId!,
-            team_group_id: teamGroupId,
-            data: {
-              station_type_id: data.station_type_id,
-              latitude: data.coordinates.lat.toString(),
-              longtitude: data.coordinates.lng.toString(),
-              station_name: data.station_name,
-              station_name_th: data.station_name_th,
-              station_name_lao: data.station_name_lao,
-              station_detail: data.station_detail,
-              station_detail_th: data.station_detail_th,
-              station_detail_lao: data.station_detail_lao,
-              status: data.status,
-              show_on_map: data.show_on_map,
-              address: data.address,
-              contact: data.contact, // เพิ่ม contact field
-              work,
-              images: data.images, // รูปใหม่ที่จะอัพโหลด
-              deletedImageIds: data.deletedImageIds, // ID ของรูปที่จะลบ
-            } as ExtendedUpdateChargingStationRequest,
-          },
-          {
-            onSuccess: () => {
-              setSelectedStation(null)
-              setSelectedStationId(null)
-              setIsEditDialogOpen(false)
-              resolve()
-              toast.success('Charging station updated successfully')
-            },
-            onError: (error) => {
-              console.error('updateStation.mutate onError called with:', error)
-              toast.error('Error updating charging station. Please try again.')
-              reject(error)
-            },
-          },
-        )
-      } catch (error) {
-        console.error('Error in handleUpdateStation try-catch:', error)
-        toast.error('Error updating charging station. Please try again.')
-        reject(error)
-      }
-    })
-  }
-
-  const handleDeleteClick = (station: ChargingStation) => {
     try {
-      setStationToDelete(station)
-      setDeleteDialogOpen(true)
+      await actions.editStation(station)
     } catch (error) {
-      console.error('Error opening delete dialog:', error)
-      toast.error('Error opening delete dialog. Please try again.')
+      toast.error('Failed to load charging station details. Please try again.')
+    }
+  }
+
+  const handleUpdateStation = async (payload: ChargingStationFormWithWork) => {
+    try {
+      await actions.updateStation(payload)
+    } catch (error) {
+      throw error
     }
   }
 
   const handleConfirmDelete = async () => {
-    if (!stationToDelete) return
     try {
-      await deleteMutation.mutateAsync(stationToDelete.id)
-
-      setDeleteDialogOpen(false)
-      setStationToDelete(null)
+      await actions.confirmDelete()
       toast.success('Charging station deleted successfully')
-    } catch (err) {
+    } catch (error) {
       toast.error('Error deleting charging station. Please try again.')
     }
   }
 
-  const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize)
-    setCurrentPage(1)
-
-    updateURL(1, newPageSize, searchQuery)
+  const handleShowEditSuccessDialog = () => {
+    dialogs.editSuccess.open()
   }
 
-  const handlePageChange = (newPage: number) => {
-    setCurrentPage(newPage)
-    updateURL(newPage, pageSize, searchQuery)
+  const handleEditSuccessDialogClose = () => {
+    actions.resetEditState()
   }
-
-  const handleSearchChange = (newSearch: string) => {
-    setSearchQuery(newSearch)
-    setCurrentPage(1)
-
-    updateURL(1, pageSize, newSearch)
-  }
-
-  const formatDateTime = (date: string, time: string) => {
-    return `${date}\n${time}`
-  }
-
-  useEffect(() => {}, [currentPage, pageSize, teamGroupId, searchQuery])
 
   return (
     <div className="space-y-6 px-3 py-4 md:px-6 lg:px-8">
-      {/* Header Section */}
       <TeamHeader teamId={teamId} pageTitle={t('team_tabs.charging_stations')} />
 
-      {/* Navigation Tabs Section */}
       <div className="">
-        <TeamTabMenu active="charging-stations" locale={String(params.locale)} teamId={teamId} />
+        <TeamTabMenu
+          active="charging-stations"
+          locale={String(params.locale)}
+          teamId={teamId}
+        />
       </div>
 
-      {/* Main Content Section */}
       <div className="flex-1">
         <div className="shadow-xs rounded-lg bg-card">
-          {/* Search and Filter Section */}
           <div className="p-3 md:p-5 lg:p-6">
             <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[1fr_auto]">
               <div className="flex flex-1 flex-wrap items-center gap-2 sm:gap-3">
                 <div className="relative w-full min-w-0 sm:w-auto sm:min-w-[16rem] md:min-w-[20rem] lg:min-w-[24rem]">
                   <Input
                     placeholder={t('charging-stations.search_by_station')}
-                    value={searchQuery}
-                    onChange={(e) => handleSearchChange(e.target.value)}
+                    value={search.query}
+                    onChange={(event) => search.onChange(event.target.value)}
                     className="h-9 w-full border-0 border-slate-200 bg-[#ECF2F8] pl-4 pr-10 placeholder:font-medium placeholder:text-[#A1B1D1] sm:h-10"
                   />
                   <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-[#A1B1D1]">
@@ -321,13 +110,15 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
                   size="sm"
                   className="h-9 gap-1 whitespace-nowrap border-0 bg-[#ECF2F8] text-xs sm:h-10 sm:text-sm"
                 >
-                  <span className="text-[#A1B1D1]">{t('charging-stations.filter_by_status')}</span>
+                  <span className="text-[#A1B1D1]">
+                    {t('charging-stations.filter_by_status')}
+                  </span>
                   <ChevronDown className="h-4 w-4 text-[#A1B1D1]" />
                 </Button>
               </div>
               <Button
                 className="h-10 w-full sm:w-auto sm:text-sm"
-                onClick={() => setIsDialogOpen(true)}
+                onClick={dialogs.add.open}
               >
                 <Plus className="size-4" />
                 {t('buttons.add')}
@@ -336,31 +127,29 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
             <Separator className="my-4" />
           </div>
 
-          {/* Table Section */}
           <ChargingStationsTable
-            chargingStations={chargingStations}
-            isLoading={isLoading}
-            error={error}
-            pageSize={pageSize}
+            chargingStations={data.chargingStations}
+            isLoading={data.isLoading}
+            error={tableError}
+            pageSize={pagination.pageSize}
             onEditStation={handleEditStation}
-            onDeleteClick={handleDeleteClick}
-            formatDateTime={formatDateTime}
+            onDeleteClick={dialogs.delete.open}
+            formatDateTime={actions.formatDateTime}
           />
 
-          {/* Pagination Section */}
           <div className="my-4 bg-card px-3 py-3 md:px-5 md:py-4 lg:px-6">
             <div className="grid grid-cols-1 items-center gap-4 sm:grid-cols-2">
               <div className="flex flex-col items-center gap-2 sm:flex-row sm:gap-4">
                 <div className="text-sm font-light text-foreground">
-                  {t('pagination.showing')} {(currentPage - 1) * pageSize + 1} {t('pagination.to')}{' '}
-                  {Math.min(currentPage * pageSize, totalItems)} {t('pagination.of')} {totalItems}{' '}
-                  {t('pagination.result')}
+                  {t('pagination.showing')} {(pagination.currentPage - 1) * pagination.pageSize + 1}{' '}
+                  {t('pagination.to')} {Math.min(pagination.currentPage * pagination.pageSize, pagination.totalItems)}{' '}
+                  {t('pagination.of')} {pagination.totalItems} {t('pagination.result')}
                 </div>
                 <div className="flex items-center">
                   <select
                     className="h-9 w-full rounded-md border bg-card px-3 py-1 text-sm sm:h-9 sm:w-auto md:px-3"
-                    value={pageSize}
-                    onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+                    value={pagination.pageSize}
+                    onChange={(event) => pagination.onPageSizeChange(Number(event.target.value))}
                   >
                     <option value="1">1 {t('pagination.list')}</option>
                     <option value="10">10 {t('pagination.list')}</option>
@@ -370,13 +159,12 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
                 </div>
               </div>
               <div className="flex items-center justify-center gap-2 sm:justify-end">
-                {/* Previous Button */}
                 <Button
                   variant={'ghost'}
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9"
-                  disabled={currentPage === 1}
-                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={pagination.currentPage === 1}
+                  onClick={() => pagination.onPageChange(pagination.currentPage - 1)}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -394,31 +182,34 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
                   </svg>
                 </Button>
 
-                {/* Page Numbers */}
                 {(() => {
-                  const pageNumbers = []
+                  const pageNumbers = [] as JSX.Element[]
                   const maxVisiblePages = 5
-                  let startPage = Math.max(1, currentPage - Math.floor(maxVisiblePages / 2))
-                  const endPage = Math.min(totalPages, startPage + maxVisiblePages - 1)
+                  let startPage = Math.max(
+                    1,
+                    pagination.currentPage - Math.floor(maxVisiblePages / 2),
+                  )
+                  const endPage = Math.min(
+                    pagination.totalPages,
+                    startPage + maxVisiblePages - 1,
+                  )
 
-                  // Adjust startPage if we're near the end
                   if (endPage - startPage < maxVisiblePages - 1) {
                     startPage = Math.max(1, endPage - maxVisiblePages + 1)
                   }
 
-                  // Always show first page
                   if (startPage > 1) {
                     pageNumbers.push(
                       <Button
                         key={1}
-                        variant={currentPage === 1 ? 'default' : 'ghost'}
+                        variant={pagination.currentPage === 1 ? 'default' : 'ghost'}
                         size="icon"
                         className={`h-8 w-8 font-light sm:h-9 sm:w-9 ${
-                          currentPage === 1
+                          pagination.currentPage === 1
                             ? 'bg-primary/20 text-primary hover:text-white'
                             : 'text-[#606266] hover:bg-gray-100'
                         }`}
-                        onClick={() => handlePageChange(1)}
+                        onClick={() => pagination.onPageChange(1)}
                       >
                         1
                       </Button>,
@@ -436,47 +227,44 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
                     }
                   }
 
-                  // Show page numbers in range
-                  for (let i = startPage; i <= endPage; i++) {
-                    if (i === 1 && startPage === 1) {
-                      // Skip if we already added page 1
+                  for (let page = startPage; page <= endPage; page++) {
+                    if (page === 1 && startPage === 1) {
                       pageNumbers.push(
                         <Button
-                          key={i}
-                          variant={currentPage === i ? 'default' : 'ghost'}
+                          key={page}
+                          variant={pagination.currentPage === page ? 'default' : 'ghost'}
                           size="icon"
                           className={`h-8 w-8 rounded-xl font-normal sm:h-9 sm:w-9 ${
-                            currentPage === i
+                            pagination.currentPage === page
                               ? 'bg-primary/20 text-primary hover:text-white'
                               : 'text-[#606266] hover:bg-gray-100'
                           }`}
-                          onClick={() => handlePageChange(i)}
+                          onClick={() => pagination.onPageChange(page)}
                         >
-                          {i}
+                          {page}
                         </Button>,
                       )
-                    } else if (i !== 1) {
+                    } else if (page !== 1) {
                       pageNumbers.push(
                         <Button
-                          key={i}
-                          variant={currentPage === i ? 'default' : 'ghost'}
+                          key={page}
+                          variant={pagination.currentPage === page ? 'default' : 'ghost'}
                           size="icon"
                           className={`h-8 w-8 font-normal sm:h-9 sm:w-9 ${
-                            currentPage === i
+                            pagination.currentPage === page
                               ? 'bg-primary/20 text-primary hover:text-white'
                               : 'text-[#606266] hover:bg-gray-100'
                           }`}
-                          onClick={() => handlePageChange(i)}
+                          onClick={() => pagination.onPageChange(page)}
                         >
-                          {i}
+                          {page}
                         </Button>,
                       )
                     }
                   }
 
-                  // Always show last page
-                  if (endPage < totalPages) {
-                    if (endPage < totalPages - 1) {
+                  if (endPage < pagination.totalPages) {
+                    if (endPage < pagination.totalPages - 1) {
                       pageNumbers.push(
                         <span
                           key="ellipsis-end"
@@ -489,17 +277,21 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
 
                     pageNumbers.push(
                       <Button
-                        key={totalPages}
-                        variant={currentPage === totalPages ? 'default' : 'ghost'}
+                        key={pagination.totalPages}
+                        variant={
+                          pagination.currentPage === pagination.totalPages
+                            ? 'default'
+                            : 'ghost'
+                        }
                         size="icon"
                         className={`h-8 w-8 font-normal sm:h-9 sm:w-9 ${
-                          currentPage === totalPages
+                          pagination.currentPage === pagination.totalPages
                             ? 'bg-primary text-white'
                             : 'text-[#606266] hover:bg-gray-100'
                         }`}
-                        onClick={() => handlePageChange(totalPages)}
+                        onClick={() => pagination.onPageChange(pagination.totalPages)}
                       >
-                        {totalPages}
+                        {pagination.totalPages}
                       </Button>,
                     )
                   }
@@ -507,13 +299,12 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
                   return pageNumbers
                 })()}
 
-                {/* Next Button */}
                 <Button
                   variant={'ghost'}
                   size="icon"
                   className="h-8 w-8 sm:h-9 sm:w-9"
-                  disabled={currentPage >= totalPages}
-                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={pagination.currentPage >= pagination.totalPages}
+                  onClick={() => pagination.onPageChange(pagination.currentPage + 1)}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -536,43 +327,38 @@ export function ChargingStationsPage({ teamId }: ChargingStationsPageProps) {
         </div>
       </div>
 
-      {/* Dialog Section */}
-      {/* Add Charging Station Dialog */}
       <AddChargingStationDialog
-        open={isDialogOpen}
-        onOpenChange={setIsDialogOpen}
+        open={dialogs.add.isOpen}
+        onOpenChange={dialogs.add.onOpenChange}
         onSubmit={handleAddStation}
         teamGroupId={teamGroupId}
       />
 
-      {/* Edit Charging Station Dialog */}
-      {selectedStation && (
+      {selection.selectedStation && (
         <EditsChargingStationDialog
-          open={isEditDialogOpen}
-          onOpenChange={setIsEditDialogOpen}
+          open={dialogs.edit.isOpen}
+          onOpenChange={dialogs.edit.onOpenChange}
           onSubmit={handleUpdateStation}
-          initialData={selectedStation} // fallback ถ้า API ล้มเหลว
+          initialData={selection.selectedStation}
           onShowSuccess={handleShowEditSuccessDialog}
         />
       )}
 
-      {/* Edit Success Dialog */}
       <SuccessDialog
-        open={showEditSuccessDialog}
-        onOpenChange={setShowEditSuccessDialog}
+        open={dialogs.editSuccess.isOpen}
+        onOpenChange={dialogs.editSuccess.onOpenChange}
         title="Success"
         message="Charging Station has been updated successfully"
         buttonText="Done"
         onButtonClick={handleEditSuccessDialogClose}
       />
 
-      {/* Delete Confirmation Dialog */}
       <DeleteConfirmDialog
-        open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
-        itemName={stationToDelete?.station_name}
+        open={dialogs.delete.isOpen}
+        onOpenChange={dialogs.delete.onOpenChange}
+        itemName={selection.stationToDelete?.station_name}
         onConfirm={handleConfirmDelete}
-        isLoading={deleteMutation.status === 'pending'}
+        isLoading={status.isDeleting}
       />
     </div>
   )

--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks/index.ts
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './use-charging-stations'
+export * from './use-charging-stations-page'

--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks/use-charging-stations-page.ts
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks/use-charging-stations-page.ts
@@ -1,0 +1,320 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+import {
+  type ChargingStation,
+  type ChargingStationsParams,
+  type CreateChargingStationRequest,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_schemas'
+import {
+  useChargingStations,
+  useCreateChargingStation,
+  useDeleteChargingStation,
+  useUpdateChargingStation,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_hooks/use-charging-stations'
+import {
+  type ChargingStationFormWithGallery,
+  type ChargingStationFormWithWork,
+  buildChargingStationsQueryParams,
+  buildUpdatedUrl,
+  ensurePartnerId,
+  extractChargingStationsData,
+  formatStationDateTime,
+  getInitialPaginationState,
+  loadStationFormData,
+  mapUpdatePayload,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services'
+
+interface UseChargingStationsPageProps {
+  teamId: string
+}
+
+interface UseChargingStationsPageResult {
+  pagination: {
+    currentPage: number
+    pageSize: number
+    totalItems: number
+    totalPages: number
+    onPageChange: (page: number) => void
+    onPageSizeChange: (size: number) => void
+  }
+  search: {
+    query: string
+    onChange: (value: string) => void
+  }
+  dialogs: {
+    add: {
+      isOpen: boolean
+      open: () => void
+      close: () => void
+      onOpenChange: (open: boolean) => void
+    }
+    edit: {
+      isOpen: boolean
+      close: () => void
+      onOpenChange: (open: boolean) => void
+    }
+    delete: {
+      isOpen: boolean
+      open: (station: ChargingStation) => void
+      close: () => void
+      onOpenChange: (open: boolean) => void
+    }
+    editSuccess: {
+      isOpen: boolean
+      open: () => void
+      close: () => void
+      onOpenChange: (open: boolean) => void
+    }
+  }
+  selection: {
+    stationToDelete: ChargingStation | null
+    selectedStation: ChargingStationFormWithGallery | null
+    selectedStationId: string | number | null
+  }
+  data: {
+    chargingStations: ChargingStation[]
+    isLoading: boolean
+    error: unknown
+  }
+  status: {
+    isDeleting: boolean
+  }
+  actions: {
+    addStation: (data: CreateChargingStationRequest) => Promise<void>
+    editStation: (station: ChargingStation) => Promise<void>
+    updateStation: (data: ChargingStationFormWithWork) => Promise<void>
+    confirmDelete: () => Promise<void>
+    formatDateTime: (date: string, time: string) => string
+    resetEditState: () => void
+  }
+}
+
+export function useChargingStationsPage(
+  props: UseChargingStationsPageProps,
+): UseChargingStationsPageResult {
+  const { teamId } = props
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const initialState = useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString())
+    return getInitialPaginationState(params)
+  }, [searchParams])
+
+  const [currentPage, setCurrentPage] = useState(initialState.currentPage)
+  const [pageSize, setPageSize] = useState(initialState.pageSize)
+  const [searchQuery, setSearchQuery] = useState(initialState.searchQuery)
+
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false)
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+  const [isEditSuccessDialogOpen, setIsEditSuccessDialogOpen] = useState(false)
+
+  const [selectedStation, setSelectedStation] =
+    useState<ChargingStationFormWithGallery | null>(null)
+  const [selectedStationId, setSelectedStationId] =
+    useState<string | number | null>(null)
+  const [stationToDelete, setStationToDelete] = useState<ChargingStation | null>(
+    null,
+  )
+
+  const teamGroupId = useMemo(() => Number.parseInt(teamId, 10), [teamId])
+
+  const createStationMutation = useCreateChargingStation()
+  const deleteStationMutation = useDeleteChargingStation()
+  const updateStationMutation = useUpdateChargingStation()
+
+  const queryParams: ChargingStationsParams = useMemo(() => {
+    return buildChargingStationsQueryParams(teamGroupId, {
+      currentPage,
+      pageSize,
+      searchQuery,
+    })
+  }, [teamGroupId, currentPage, pageSize, searchQuery])
+
+  const {
+    data: stationsResponse,
+    isLoading,
+    error,
+  } = useChargingStations(queryParams)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const pathname = window.location.pathname
+    const url = buildUpdatedUrl(pathname, {
+      currentPage,
+      pageSize,
+      searchQuery,
+    })
+
+    router.replace(url, { scroll: false })
+  }, [currentPage, pageSize, searchQuery, router])
+
+  const { list: chargingStations, totalItems, totalPages } = useMemo(() => {
+    return extractChargingStationsData(stationsResponse)
+  }, [stationsResponse])
+
+  const addStation = useCallback(
+    async (data: CreateChargingStationRequest) => {
+      ensurePartnerId()
+      await createStationMutation.mutateAsync(data)
+      setIsAddDialogOpen(false)
+    },
+    [createStationMutation],
+  )
+
+  const editStation = useCallback(
+    async (station: ChargingStation) => {
+      const formData = await loadStationFormData(station.id)
+      setSelectedStation({
+        ...formData,
+        existingGallery: formData.existingGallery,
+      })
+      setSelectedStationId(station.id)
+      setIsEditDialogOpen(true)
+    },
+    [],
+  )
+
+  const updateStation = useCallback(
+    async (data: ChargingStationFormWithWork) => {
+      if (!selectedStationId) {
+        throw new Error('No charging station selected for update')
+      }
+
+      const payload = mapUpdatePayload(selectedStationId, teamGroupId, data)
+      await updateStationMutation.mutateAsync(payload)
+      setSelectedStation(null)
+      setSelectedStationId(null)
+      setIsEditDialogOpen(false)
+    },
+    [selectedStationId, teamGroupId, updateStationMutation],
+  )
+
+  const confirmDelete = useCallback(async () => {
+    if (!stationToDelete) return
+
+    await deleteStationMutation.mutateAsync(stationToDelete.id)
+    setStationToDelete(null)
+    setIsDeleteDialogOpen(false)
+  }, [deleteStationMutation, stationToDelete])
+
+  const resetEditState = useCallback(() => {
+    setIsEditSuccessDialogOpen(false)
+    setSelectedStation(null)
+    setSelectedStationId(null)
+    setIsEditDialogOpen(false)
+  }, [])
+
+  const onPageSizeChange = useCallback(
+    (size: number) => {
+      setPageSize(size)
+      setCurrentPage(1)
+    },
+    [],
+  )
+
+  const onPageChange = useCallback((page: number) => {
+    setCurrentPage(page)
+  }, [])
+
+  const onSearchChange = useCallback((value: string) => {
+    setSearchQuery(value)
+    setCurrentPage(1)
+  }, [])
+
+  const openDeleteDialog = useCallback((station: ChargingStation) => {
+    setStationToDelete(station)
+    setIsDeleteDialogOpen(true)
+  }, [])
+
+  const onDeleteDialogChange = useCallback((open: boolean) => {
+    setIsDeleteDialogOpen(open)
+    if (!open) {
+      setStationToDelete(null)
+    }
+  }, [])
+
+  const openEditSuccessDialog = useCallback(() => {
+    setIsEditSuccessDialogOpen(true)
+  }, [])
+
+  const closeEditSuccessDialog = useCallback(() => {
+    resetEditState()
+  }, [resetEditState])
+
+  const onEditSuccessDialogChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setIsEditSuccessDialogOpen(true)
+        return
+      }
+      resetEditState()
+    },
+    [resetEditState],
+  )
+
+  return {
+    pagination: {
+      currentPage,
+      pageSize,
+      totalItems,
+      totalPages,
+      onPageChange,
+      onPageSizeChange,
+    },
+    search: {
+      query: searchQuery,
+      onChange: onSearchChange,
+    },
+    dialogs: {
+      add: {
+        isOpen: isAddDialogOpen,
+        open: () => setIsAddDialogOpen(true),
+        close: () => setIsAddDialogOpen(false),
+        onOpenChange: setIsAddDialogOpen,
+      },
+      edit: {
+        isOpen: isEditDialogOpen,
+        close: () => setIsEditDialogOpen(false),
+        onOpenChange: setIsEditDialogOpen,
+      },
+      delete: {
+        isOpen: isDeleteDialogOpen,
+        open: openDeleteDialog,
+        close: () => setIsDeleteDialogOpen(false),
+        onOpenChange: onDeleteDialogChange,
+      },
+      editSuccess: {
+        isOpen: isEditSuccessDialogOpen,
+        open: openEditSuccessDialog,
+        close: closeEditSuccessDialog,
+        onOpenChange: onEditSuccessDialogChange,
+      },
+    },
+    selection: {
+      stationToDelete,
+      selectedStation,
+      selectedStationId,
+    },
+    data: {
+      chargingStations,
+      isLoading,
+      error,
+    },
+    status: {
+      isDeleting: deleteStationMutation.status === 'pending',
+    },
+    actions: {
+      addStation,
+      editStation,
+      updateStation,
+      confirmDelete,
+      formatDateTime: formatStationDateTime,
+      resetEditState,
+    },
+  }
+}

--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/charging-stations-page.service.ts
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/charging-stations-page.service.ts
@@ -1,0 +1,148 @@
+import {
+  fetchChargingStationDetail,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_api/charging-stations.api'
+import {
+  type ChargingStationsParams,
+  type ChargingStationsResponse,
+  type ChargingStationFormData,
+  type ExtendedUpdateChargingStationRequest,
+  type PartnerStationGalleryDetail,
+  type WorkTime,
+} from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_schemas'
+import { convertStationDetailToFormData } from '@/app/[locale]/(back-office)/team/[teamId]/charging-stations/_utils'
+import { getPartnerIdFromStorage } from '@/lib/utils/user-storage'
+
+export interface PaginationState {
+  currentPage: number
+  pageSize: number
+  searchQuery: string
+}
+
+export interface ChargingStationFormWithWork extends ChargingStationFormData {
+  work?: WorkTime[]
+  images?: globalThis.File[]
+  deletedImageIds?: number[]
+}
+
+export type ChargingStationFormWithGallery = ChargingStationFormData & {
+  existingGallery: PartnerStationGalleryDetail[]
+}
+
+export function getInitialPaginationState(
+  searchParams: Readonly<URLSearchParams> | URLSearchParams,
+): PaginationState {
+  const pageParam = searchParams.get('page')
+  const pageSizeParam = searchParams.get('pageSize')
+  const searchParam = searchParams.get('search')
+
+  return {
+    currentPage: pageParam ? Number.parseInt(pageParam, 10) || 1 : 1,
+    pageSize: pageSizeParam ? Number.parseInt(pageSizeParam, 10) || 10 : 10,
+    searchQuery: searchParam ?? '',
+  }
+}
+
+export function buildChargingStationsQueryParams(
+  teamGroupId: number,
+  state: PaginationState,
+): ChargingStationsParams {
+  const params: ChargingStationsParams = {
+    team_group_id: teamGroupId,
+    page: state.currentPage,
+    pageSize: state.pageSize,
+  }
+
+  if (state.searchQuery.trim()) {
+    params.search = state.searchQuery.trim()
+  }
+
+  return params
+}
+
+export function buildUpdatedUrl(pathname: string, state: PaginationState): string {
+  const params = new URLSearchParams()
+  params.set('page', state.currentPage.toString())
+  params.set('pageSize', state.pageSize.toString())
+
+  if (state.searchQuery.trim()) {
+    params.set('search', state.searchQuery.trim())
+  }
+
+  const queryString = params.toString()
+  return queryString ? `${pathname}?${queryString}` : pathname
+}
+
+export function extractChargingStationsData(response?: ChargingStationsResponse | null) {
+  return {
+    list: response?.data?.data ?? [],
+    totalItems: response?.data?.item_total ?? 0,
+    totalPages: response?.data?.page_total ?? 1,
+  }
+}
+
+export function formatStationDateTime(date: string, time: string) {
+  return `${date}\n${time}`
+}
+
+export async function loadStationFormData(
+  stationId: string | number,
+): Promise<ChargingStationFormWithGallery> {
+  const response = await fetchChargingStationDetail(stationId)
+  const rawData = Array.isArray(response.data) ? response.data[0] : response.data
+
+  const converted = convertStationDetailToFormData(rawData)
+  const { existingGallery, ...formData } = converted
+
+  return {
+    ...formData,
+    existingGallery,
+  }
+}
+
+export function mapUpdatePayload(
+  stationId: string | number,
+  teamGroupId: number,
+  data: ChargingStationFormWithWork,
+): {
+  stationId: string | number
+  team_group_id: number
+  data: ExtendedUpdateChargingStationRequest
+} {
+  const work: WorkTime[] = data.work ?? []
+
+  const payload: ExtendedUpdateChargingStationRequest = {
+    station_type_id: data.station_type_id,
+    latitude: data.coordinates.lat.toString(),
+    longtitude: data.coordinates.lng.toString(),
+    station_name: data.station_name,
+    station_name_th: data.station_name_th,
+    station_name_lao: data.station_name_lao,
+    station_detail: data.station_detail,
+    station_detail_th: data.station_detail_th,
+    station_detail_lao: data.station_detail_lao,
+    status: data.status,
+    show_on_map: data.show_on_map,
+    address: data.address,
+    contact: data.contact,
+    work,
+    images: data.images,
+    deletedImageIds: data.deletedImageIds,
+  }
+
+  return {
+    stationId,
+    team_group_id: teamGroupId,
+    data: payload,
+  }
+}
+
+export function ensurePartnerId(): string {
+  const partnerId = getPartnerIdFromStorage()
+
+  if (!partnerId) {
+    throw new Error('Partner ID not found. Please log in again.')
+  }
+
+  return partnerId
+}
+

--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/index.ts
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/index.ts
@@ -1,0 +1,1 @@
+export * from './charging-stations-page.service'


### PR DESCRIPTION
## Summary
- extract charging station page state management into a dedicated useChargingStationsPage hook
- add charging-stations-page.service utilities to encapsulate pagination, payload mapping, and detail loading logic
- simplify ChargingStationsPage component to consume the new hook/services while keeping UI concerns isolated

## Testing
- pnpm lint *(fails: Next.js lint command expects a pages or app directory at the repo root)*

------
https://chatgpt.com/codex/tasks/task_e_68cdeb2ad860832e85e8aefe72880360