### PR TITLE
Fix charging station update payload typing

### DIFF
--- a/src/modules/charging-stations/schemas/charging-stations.schema.ts
+++ b/src/modules/charging-stations/schemas/charging-stations.schema.ts
@@ -83,7 +83,7 @@ export const CreateChargingStationRequestSchema = z.object({
   station_detail: z.string().min(1),
   station_detail_th: z.string().optional(),
   station_detail_lao: z.string().optional(),
-  station_type_id: z.number().min(1),
+  station_type_id: z.union([z.number().min(1), z.string().min(1)]),
   address: z.string().min(1),
   status: z.number().min(1).max(6),
   show_on_map: z.boolean(),

--- a/src/modules/charging-stations/services/charging-stations-page-service.ts
+++ b/src/modules/charging-stations/services/charging-stations-page-service.ts
@@ -147,8 +147,19 @@ export function buildUpdateStationRequest(
   submission: ChargingStationFormSubmission,
   stationId: string | number,
 ): ExtendedUpdateChargingStationRequest {
-  return {
-    id: normalizeStationId(stationId),
+  const normalizedStationId = normalizeStationId(stationId)
+  const workSchedule = submission.work ?? []
+  const stationTypeIdValue =
+    typeof submission.station_type_id === 'string'
+      ? Number.parseInt(submission.station_type_id, 10)
+      : submission.station_type_id
+
+  if (Number.isNaN(stationTypeIdValue)) {
+    throw new Error('Invalid station type id')
+  }
+
+  const request: ExtendedUpdateChargingStationRequest = {
+    id: normalizedStationId,
     latitude: submission.coordinates.lat.toString(),
     longtitude: submission.coordinates.lng.toString(),
     station_name: submission.station_name,
@@ -157,15 +168,17 @@ export function buildUpdateStationRequest(
     station_detail: submission.station_detail,
     station_detail_th: submission.station_detail_th,
     station_detail_lao: submission.station_detail_lao,
-    station_type_id: submission.station_type_id,
+    station_type_id: stationTypeIdValue,
     address: submission.address,
     status: submission.status,
     show_on_map: submission.show_on_map,
-    work: submission.work ?? [],
+    work: workSchedule,
     contact: submission.contact ?? '',
     image: submission.images,
     deletedImageIds: submission.deletedImageIds,
   }
+
+  return request
 }
 
 export async function createStationRecord(


### PR DESCRIPTION
## Summary
- normalize the update request payload for charging stations so the station id and work data are always typed correctly and guard against invalid station type identifiers
- loosen the charging station request schema to accept string station type ids coming from form submissions

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*
- pnpm exec tsc --noEmit *(fails: existing type errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8420e548832ea112613c54126f33