### PR TITLE
Fix charging station update payload typing

### DIFF
--- a/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/charging-stations-page.service.ts
+++ b/src/src/app/[locale]/(back-office)/team/[teamId]/charging-stations/_services/charging-stations-page.service.ts
@@ -109,8 +109,15 @@ export function mapUpdatePayload(
   data: ExtendedUpdateChargingStationRequest
 } {
   const work: WorkTime[] = data.work ?? []
+  const numericStationId =
+    typeof stationId === 'string' ? Number(stationId) : stationId
+
+  if (Number.isNaN(numericStationId)) {
+    throw new Error('Invalid station ID provided for update')
+  }
 
   const payload: ExtendedUpdateChargingStationRequest = {
+    id: numericStationId,
     station_type_id: data.station_type_id,
     latitude: data.coordinates.lat.toString(),
     longtitude: data.coordinates.lng.toString(),
@@ -136,7 +143,7 @@ export function mapUpdatePayload(
   }
 }
 
-export function ensurePartnerId(): string {
+export function ensurePartnerId(): number {
   const partnerId = getPartnerIdFromStorage()
 
   if (!partnerId) {


### PR DESCRIPTION
## Summary
- ensure the update payload always includes a numeric station id that matches the API contract
- validate station id inputs and adjust partner id helper typing to reflect the stored number value

## Testing
- pnpm lint:check *(fails: `next lint` requires a root `pages` or `app` directory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8e584428832eaa02d9bdbda8292a