### PR TITLE
Fix team price group forms to read teamId param

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/add/price-group/add-price-group.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/add/price-group/add-price-group.tsx
@@ -18,7 +18,7 @@ import {
 export default function AddPriceGroup() {
   const router = useRouter()
   const params = useParams()
-  const teamId = params.id as string
+  const teamId = params.teamId as string
   const [isSuccess, setIsSuccess] = useState(false)
 
   // Hooks for API calls

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/add/price-group/memeber-price/add-member-price-group.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/add/price-group/memeber-price/add-member-price-group.tsx
@@ -19,7 +19,7 @@ import {
 export default function AddMemberPriceGroup() {
   const router = useRouter()
   const params = useParams()
-  const teamId = params.id as string
+  const teamId = params.teamId as string
   const [isSuccess, setIsSuccess] = useState(false)
 
   // Hooks for API calls

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/price-group/edit-price-group.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/price-group/edit-price-group.tsx
@@ -21,7 +21,7 @@ export default function EditPriceGroup() {
   const router = useRouter()
   const params = useParams()
   const searchParams = useSearchParams()
-  const teamId = params.id as string
+  const teamId = params.teamId as string
   const priceId = searchParams.get('priceId')
   const [isSuccess, setIsSuccess] = useState(false)
 

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/price-group/memeber-price/edit-member-price-group.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/price-group/memeber-price/edit-member-price-group.tsx
@@ -23,7 +23,7 @@ export default function EditMemberPriceGroup() {
   const router = useRouter()
   const params = useParams()
   const searchParams = useSearchParams()
-  const teamId = params.id as string
+  const teamId = params.teamId as string
   const priceId = searchParams.get('priceId')
   const [isSuccess, setIsSuccess] = useState(false)
 


### PR DESCRIPTION
## Summary
- update price group add/edit components to read the `teamId` route param so member forms resolve the team group data correctly

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d15376db28832ebc52128a1a0af194