### PR TITLE
Fix charger creation success handling

### DIFF
--- a/src/components/back-office/team/add/chargers/add-charger-dialog.tsx
+++ b/src/components/back-office/team/add/chargers/add-charger-dialog.tsx
@@ -323,7 +323,13 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
         // Create the charger
         const response = await createCharger(teamGroupId!, chargerData)
 
-        if (response.statusCode === 200 || response.statusCode === 201) {
+        const normalizedStatusCode = Number(response.statusCode)
+        const isSuccessfulStatus =
+          !Number.isNaN(normalizedStatusCode) &&
+          normalizedStatusCode >= 200 &&
+          normalizedStatusCode < 300
+
+        if (isSuccessfulStatus) {
           console.log('Charger created successfully, response:', response)
           console.log('Response data structure:', response.data)
           // Try multiple possible response structures


### PR DESCRIPTION
## Summary
- normalize the success check after creating a charger so any 2xx status is treated as successful
- parse and normalize the status code returned from the createCharger API call while surfacing API error messages

## Testing
- pnpm lint:check *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d15f2c8a04832e897fabef0c54dee3