### PR TITLE
Ensure charger creation confirmation advances to step two

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/(back-office)/team/[teamId]/chargers/_components/chargers/add-charger-dialog.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/chargers/_components/chargers/add-charger-dialog.tsx
@@ -56,6 +56,7 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
   const ocppUrlInputRef = useRef<HTMLInputElement>(null)
   const closeReasonRef = useRef<'success' | null>(null)
   const preserveStateForStepTwoRef = useRef(false)
+  const resumeStepRef = useRef<number | null>(null)
 
   // Initialize form
   const form = useForm<ChargerFormData>({
@@ -95,6 +96,11 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
 
   const dialogOpen = isControlled ? open : internalOpen
   const setDialogOpen = isControlled ? onOpenChange : setInternalOpen
+  const setDialogOpenRef = useRef<typeof setDialogOpen>(setDialogOpen)
+
+  useEffect(() => {
+    setDialogOpenRef.current = setDialogOpen
+  }, [setDialogOpen])
 
   const createChargerMutation = useCreateCharger(teamGroupId)
   const updateSerialNumberMutation = useUpdateSerialNumber()
@@ -142,9 +148,21 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
   }
 
   useEffect(() => {
-    if (!confirmDialogOpen && closeReasonRef.current === 'success' && !preserveStateForStepTwoRef.current) {
-      resetForm()
-      closeReasonRef.current = null
+    if (!confirmDialogOpen) {
+      if (resumeStepRef.current !== null) {
+        const nextStep = resumeStepRef.current
+        resumeStepRef.current = null
+        setCurrentStep(nextStep)
+        preserveStateForStepTwoRef.current = false
+        closeReasonRef.current = null
+        setDialogOpenRef.current?.(true)
+        return
+      }
+
+      if (closeReasonRef.current === 'success' && !preserveStateForStepTwoRef.current) {
+        resetForm()
+        closeReasonRef.current = null
+      }
     }
   }, [confirmDialogOpen])
 
@@ -344,13 +362,41 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
 
         const response = await createChargerMutation.mutateAsync(chargerData)
 
-        const normalizedStatus =
-          typeof response.statusCode === 'number'
-            ? response.statusCode
-            : (response as { status?: number }).status
+        const normalizedStatus = (() => {
+          if (typeof response.statusCode === 'number') {
+            return response.statusCode
+          }
+
+          if (typeof (response as { statusCode?: string }).statusCode === 'string') {
+            const parsed = Number((response as { statusCode?: string }).statusCode)
+            if (!Number.isNaN(parsed)) {
+              return parsed
+            }
+          }
+
+          const fallbackStatus = (response as { status?: number | string }).status
+
+          if (typeof fallbackStatus === 'number') {
+            return fallbackStatus
+          }
+
+          if (typeof fallbackStatus === 'string') {
+            const parsed = Number(fallbackStatus)
+            if (!Number.isNaN(parsed)) {
+              return parsed
+            }
+          }
+
+          return undefined
+        })()
+
         const isSuccessfulResponse =
-          (typeof normalizedStatus === 'number' && normalizedStatus >= 200 && normalizedStatus < 300) ||
-          response.message?.toLowerCase() === 'success'
+          (typeof normalizedStatus === 'number' &&
+            !Number.isNaN(normalizedStatus) &&
+            normalizedStatus >= 200 &&
+            normalizedStatus < 300) ||
+          response.message?.toLowerCase() === 'success' ||
+          response.data?.message?.toLowerCase() === 'success'
 
         if (isSuccessfulResponse) {
           // Try multiple possible response structures
@@ -447,11 +493,8 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
 
   const handleConfirmNext = () => {
     preserveStateForStepTwoRef.current = true
+    resumeStepRef.current = 2
     setConfirmDialogOpen(false)
-    // เปิด dialog อีกครั้งด้วย step 2
-    setCurrentStep(2)
-    closeReasonRef.current = null
-    setDialogOpen?.(true)
   }
 
   const handleBack = () => {


### PR DESCRIPTION
## Summary
- add a resume step ref that reopens the add charger dialog at step two after the confirmation dialog closes so successful creations can proceed
- keep the latest dialog open handler in a ref and reuse it when resuming the flow to work for both controlled and uncontrolled usages
- include the generated Next.js routes type reference so local linting stays in sync

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d1612cf548832eb99a8f178e5cdf8b