### PR TITLE
Ensure Add Charger dialog resumes after confirmation

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/chargers/_components/chargers/add-charger-dialog.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/chargers/_components/chargers/add-charger-dialog.tsx
@@ -56,7 +56,7 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
   const ocppUrlInputRef = useRef<HTMLInputElement>(null)
   const closeReasonRef = useRef<'success' | null>(null)
   const preserveStateForStepTwoRef = useRef(false)
-  const resumeStepRef = useRef<number | null>(null)
+  const resumeDialogAfterConfirmRef = useRef(false)
 
   // Initialize form
   const form = useForm<ChargerFormData>({
@@ -149,17 +149,12 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
 
   useEffect(() => {
     if (!confirmDialogOpen) {
-      if (resumeStepRef.current !== null) {
-        const nextStep = resumeStepRef.current
-        resumeStepRef.current = null
-        setCurrentStep(nextStep)
-        preserveStateForStepTwoRef.current = false
-        closeReasonRef.current = null
-        setDialogOpenRef.current?.(true)
-        return
-      }
-
-      if (closeReasonRef.current === 'success' && !preserveStateForStepTwoRef.current) {
+      if (resumeDialogAfterConfirmRef.current) {
+        resumeDialogAfterConfirmRef.current = false
+        if (setDialogOpenRef.current) {
+          setDialogOpenRef.current(true)
+        }
+      } else if (closeReasonRef.current === 'success' && !preserveStateForStepTwoRef.current) {
         resetForm()
         closeReasonRef.current = null
       }
@@ -512,8 +507,11 @@ export function AddChargerDialog({ open, onOpenChange, teamGroupId }: AddCharger
 
   const handleConfirmNext = () => {
     preserveStateForStepTwoRef.current = true
-    resumeStepRef.current = 2
+    resumeDialogAfterConfirmRef.current = true
     setConfirmDialogOpen(false)
+
+    setCurrentStep(2)
+    closeReasonRef.current = null
   }
 
   const handleBack = () => {


### PR DESCRIPTION
## Summary
- add a resumeDialogAfterConfirmRef to track when the wizard should reopen after the confirmation dialog closes
- resume the primary Add Charger dialog from the confirmation dialog effect so step two reliably appears after pressing Continue

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d17e516c24832ea2b655620ad381ef