### PR TITLE
feat: allow plan upgrade component to use api packages

### DIFF
--- a/src/components/back-office/team/settings/plan/plan-upgrade-content.tsx
+++ b/src/components/back-office/team/settings/plan/plan-upgrade-content.tsx
@@ -10,6 +10,60 @@ import { BillingInformation, type BillingData } from './billing-information'
 import { PricingPackages } from './pricing-packages'
 import { pricingPlanSchema, type PricingPlan } from './plans.schema'
 
+const defaultPricingPlans = pricingPlanSchema.array().parse([
+  {
+    id: 'starter',
+    icon_package_path: 'lucide:zap',
+    package_name: 'Starter',
+    type_of_prices: 'month',
+    description: 'Perfect for small teams getting started',
+    price: '129',
+    detail: [
+      'Up to 5 charging stations',
+      'Basic analytics',
+      'Email support',
+      '5GB storage',
+      'Standard integrations',
+    ],
+  },
+  {
+    id: 'professional',
+    icon_package_path: 'lucide:crown',
+    package_name: 'Professional',
+    type_of_prices: 'month',
+    description: 'Best for growing businesses',
+    price: '329',
+    detail: [
+      'Up to 25 charging stations',
+      'Advanced analytics & reporting',
+      'Priority support',
+      '50GB storage',
+      'API access',
+      'Custom branding',
+      'Multi-location support',
+    ],
+    is_default: true,
+  },
+  {
+    id: 'enterprise',
+    icon_package_path: 'lucide:star',
+    package_name: 'Enterprise',
+    type_of_prices: 'month',
+    description: 'For large scale operations',
+    price: '999',
+    detail: [
+      'Unlimited charging stations',
+      'Real-time monitoring',
+      '24/7 phone support',
+      'Unlimited storage',
+      'Custom integrations',
+      'White-label solution',
+      'Dedicated account manager',
+      'SLA guarantee',
+    ],
+  },
+])
+
 export interface UsageData {
   stations: { used: number; limit: number }
   members: { used: number; limit: number }
@@ -19,6 +73,7 @@ export interface PlanUpgradeContentProps {
   usage: UsageData
   currentPlan?: string
   currentPlanId?: string
+  plans?: PricingPlan[]
   upgradePlanAction: (teamId: string, planId: string) => Promise<{ error?: string } | void>
   teamId: string
   billingData: BillingData
@@ -29,8 +84,9 @@ export interface PlanUpgradeContentProps {
 
 export function PlanUpgradeContent({
   usage,
-  currentPlan = 'Professional',
-  currentPlanId = 'professional',
+  currentPlan,
+  currentPlanId,
+  plans = defaultPricingPlans,
   upgradePlanAction,
   teamId,
   billingData,
@@ -43,67 +99,22 @@ export function PlanUpgradeContent({
   const stationsPct = Math.round((usage.stations.used / usage.stations.limit) * 100)
   const membersPct = Math.round((usage.members.used / usage.members.limit) * 100)
 
-  const pricingPlans: PricingPlan[] = pricingPlanSchema.array().parse([
-    {
-      id: 'starter',
-      icon_package_path: 'lucide:zap',
-      package_name: 'Starter',
-      type_of_prices: 'month',
-      description: 'Perfect for small teams getting started',
-      price: '129',
-      detail: [
-        'Up to 5 charging stations',
-        'Basic analytics',
-        'Email support',
-        '5GB storage',
-        'Standard integrations',
-      ],
-    },
-    {
-      id: 'professional',
-      icon_package_path: 'lucide:crown',
-      package_name: 'Professional',
-      type_of_prices: 'month',
-      description: 'Best for growing businesses',
-      price: '329',
-      detail: [
-        'Up to 25 charging stations',
-        'Advanced analytics & reporting',
-        'Priority support',
-        '50GB storage',
-        'API access',
-        'Custom branding',
-        'Multi-location support',
-      ],
-      is_default: true,
-    },
-    {
-      id: 'enterprise',
-      icon_package_path: 'lucide:star',
-      package_name: 'Enterprise',
-      type_of_prices: 'month',
-      description: 'For large scale operations',
-      price: '999',
-      detail: [
-        'Unlimited charging stations',
-        'Real-time monitoring',
-        '24/7 phone support',
-        'Unlimited storage',
-        'Custom integrations',
-        'White-label solution',
-        'Dedicated account manager',
-        'SLA guarantee',
-      ],
-    },
-  ])
+  const pricingPlans: PricingPlan[] = pricingPlanSchema.array().parse(plans)
+
+  const fallbackPlan =
+    pricingPlans.find((plan) => plan.is_default) ?? pricingPlans[0] ?? undefined
 
   const activePlan =
-    pricingPlans.find((plan) => plan.id === currentPlanId) ??
-    pricingPlans.find((plan) => plan.is_default) ??
-    pricingPlans[0]
+    (currentPlanId && pricingPlans.find((plan) => plan.id === currentPlanId)) ??
+    (currentPlan && pricingPlans.find((plan) => plan.package_name === currentPlan)) ??
+    fallbackPlan
 
-  const activePlanName = activePlan?.package_name ?? currentPlan
-  const activePlanId = activePlan?.id ?? currentPlanId
+  const activePlanName =
+    activePlan?.package_name ??
+    currentPlan ??
+    fallbackPlan?.package_name ??
+    '—'
+  const activePlanId = activePlan?.id ?? currentPlanId ?? fallbackPlan?.id
 
   const handleUpgrade = (planId: string) => {
     startTransition(async () => {

--- a/src/components/back-office/team/settings/plan/plans.schema.ts
+++ b/src/components/back-office/team/settings/plan/plans.schema.ts
@@ -6,7 +6,7 @@ export const pricingPlanSchema = z.object({
   package_name: z.string(),
   type_of_prices: z.string(),
   description: z.string(),
-  price: z.string(),
+  price: z.union([z.string(), z.number()]),
   detail: z.array(z.string()),
   discount: z.string().optional(),
   commission: z.string().optional(),

--- a/src/components/back-office/team/settings/plan/pricing-packages.tsx
+++ b/src/components/back-office/team/settings/plan/pricing-packages.tsx
@@ -59,10 +59,15 @@ export function PricingPackages({
           const isCurrentPlan = plan.id === currentPlanId
           const isRecommendedPlan = plan.is_default && !isCurrentPlan
 
+          const formattedPrice =
+            typeof plan.price === 'number'
+              ? plan.price.toLocaleString()
+              : plan.price
+
           const cardStateClass = isCurrentPlan
             ? 'border-2 border-green-500'
             : isRecommendedPlan
-              ? 'border-2 border-primary'
+                ? 'border-2 border-primary'
               : ''
 
           return (
@@ -93,9 +98,19 @@ export function PricingPackages({
                   </div>
                   <h3 className="text-xl font-medium">{plan.package_name}</h3>
                   <div className="mt-2">
-                    <span className="text-3xl font-bold">฿{plan.price}</span>
+                    <span className="text-3xl font-bold">฿{formattedPrice}</span>
                     <span className="text-muted-foreground">/{plan.type_of_prices}</span>
                   </div>
+                  {plan.discount && (
+                    <p className="mt-1 text-xs font-semibold text-primary">
+                      Save {plan.discount}
+                    </p>
+                  )}
+                  {plan.commission && (
+                    <p className="text-xs text-muted-foreground">
+                      Commission fee {plan.commission}
+                    </p>
+                  )}
                   <p className="mt-2 text-sm text-muted-foreground">{plan.description}</p>
                 </div>
 


### PR DESCRIPTION
## Summary
- allow the plan upgrade content component to consume pricing plans from props and derive the active package from API keys
- support numeric plan prices and surface optional discount/commission messaging in the pricing cards

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ad137804832ea2f70f2ecfb875a2