### PR TITLE
Show only current plan in plan module

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/plan-upgrade-content.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/plan-upgrade-content.tsx
@@ -12,12 +12,12 @@ import { PricingPackages } from './pricing-packages'
 
 const defaultPricingPlans = pricingPlanSchema.array().parse([
   {
-    id: 'professional',
-    icon_package_path: 'lucide:crown',
-    package_name: 'Professional',
+    id: '24',
+    icon_package_path: 'https://example.com/icon-package.png',
+    package_name: 'Pro',
     type_of_prices: 'month',
-    description: 'Best for growing businesses',
-    price: '329',
+    description: '2',
+    price: '150.00',
     detail: [
       'Up to 25 charging stations',
       'Advanced analytics & reporting',
@@ -27,6 +27,8 @@ const defaultPricingPlans = pricingPlanSchema.array().parse([
       'Custom branding',
       'Multi-location support',
     ],
+    discount: '20.00',
+    commission: '2.00',
     is_default: true,
   },
 ])

--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/pricing-packages.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/pricing-packages.tsx
@@ -49,10 +49,28 @@ export function PricingPackages({
     )
   }
 
-  const visiblePlans = currentPlanId ? plans.filter((plan) => plan.id === currentPlanId) : plans
+  const visiblePlans = (() => {
+    if (currentPlanId) {
+      const currentPlan = plans.find((plan) => plan.id === currentPlanId)
+
+      return currentPlan ? [currentPlan] : []
+    }
+
+    const defaultPlan = plans.find((plan) => plan.is_default)
+
+    if (defaultPlan) {
+      return [defaultPlan]
+    }
+
+    return plans.length > 0 ? [plans[0]] : []
+  })()
 
   const gridColumnsClass =
-    plans.length >= 3 ? 'md:grid-cols-3' : plans.length === 2 ? 'md:grid-cols-2' : 'md:grid-cols-1'
+    visiblePlans.length >= 3
+      ? 'md:grid-cols-3'
+      : visiblePlans.length === 2
+        ? 'md:grid-cols-2'
+        : 'md:grid-cols-1'
 
   return (
     <div className="mt-10">


### PR DESCRIPTION
## Summary
- align the default plan seed data with the latest pricing plan API schema
- rely on zod-validated plan data to surface only the active plan in the pricing UI and adjust the grid layout accordingly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b3a88308832eb87682c4e7378f45