### PR TITLE
Handle string data payloads from login endpoint

### DIFF
--- a/src/app/api/auth/sign-in/route.ts
+++ b/src/app/api/auth/sign-in/route.ts
@@ -1,6 +1,10 @@
 // src/app/api/auth/sign-in/route.ts
 import { COOKIE_KEYS } from '@/lib/constants'
-import { BackendLoginSchema, SignInSchema } from '@/modules/auth/models/sign-in.schema'
+import {
+  BackendLoginSchema,
+  SignInSchema,
+  type BackendLoginData,
+} from '@/modules/auth/models/sign-in.schema'
 import { NextRequest, NextResponse } from 'next/server'
 
 const API_BASE_URL = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_BASE_URL
@@ -69,7 +73,21 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ message: 'Invalid response schema' }, { status: 502 })
     }
 
-    const { access_token, refresh_token, user } = result.data.data
+    const loginData = result.data.data
+
+    if (!loginData || typeof loginData === 'string') {
+      const fallbackMessage =
+        (typeof loginData === 'string' && loginData.trim().length > 0
+          ? loginData
+          : result.data.message) || 'Invalid response payload'
+      console.error('[API] /api/auth/sign-in: unexpected data payload', {
+        payloadType: typeof loginData,
+        hasMessage: !!result.data.message,
+      })
+      return NextResponse.json({ message: fallbackMessage }, { status: 502 })
+    }
+
+    const { access_token, refresh_token, user } = loginData as BackendLoginData
 
     // Build user_data payload example for client visibility (non-sensitive)
     const user_data = {

--- a/src/modules/auth/models/sign-in.schema.ts
+++ b/src/modules/auth/models/sign-in.schema.ts
@@ -17,14 +17,23 @@ export const SignInSchema = z
 export type SignInInput = z.infer<typeof SignInSchema>
 
 // Expected backend response wrapper for sign-in
+export const BackendLoginDataSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  user: z.unknown(),
+})
+
 export const BackendLoginSchema = z.object({
   statusCode: z.number(),
   message: z.string().optional(),
-  data: z.object({
-    access_token: z.string(),
-    refresh_token: z.string(),
-    user: z.unknown(),
-  }),
+  data: z
+    .union([
+      BackendLoginDataSchema,
+      z.string(),
+      z.null(),
+      z.undefined(),
+    ])
+    .optional(),
 })
 
 // Normalized login response used by FE after internal route
@@ -35,3 +44,4 @@ export const LoginResponseSchema = z.object({
 })
 
 export type LoginResponse = z.infer<typeof LoginResponseSchema>
+export type BackendLoginData = z.infer<typeof BackendLoginDataSchema>


### PR DESCRIPTION
## Summary
- broaden the backend login schema to allow string or empty payloads while keeping the typed token structure
- guard the sign-in API route against non-object data payloads and surface a clearer 502 response when the backend returns a string message

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d247ccd368832e99567b6e8ec672f1