### PR TITLE
feat: load team pricing plans on upgrade settings

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/pricing-packages.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_components/plan/pricing-packages.tsx
@@ -49,21 +49,7 @@ export function PricingPackages({
     )
   }
 
-  const visiblePlans = (() => {
-    if (currentPlanId) {
-      const currentPlan = plans.find((plan) => plan.id === currentPlanId)
-
-      return currentPlan ? [currentPlan] : []
-    }
-
-    const defaultPlan = plans.find((plan) => plan.is_default)
-
-    if (defaultPlan) {
-      return [defaultPlan]
-    }
-
-    return plans.length > 0 ? [plans[0]] : []
-  })()
+  const visiblePlans = plans.length > 0 ? plans : []
 
   const gridColumnsClass =
     visiblePlans.length >= 3

--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_hooks/use-plans.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_hooks/use-plans.ts
@@ -1,0 +1,59 @@
+import { QUERY_KEYS } from '@/lib/constants'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { pricingPlanSchema, type PricingPlan } from '../_schemas/plans.schema'
+import { getPricingPlans } from '../_servers/plans.actions'
+
+export const useTeamPricingPlans = (teamId?: string, initialPlans?: PricingPlan[]) => {
+  const safeInitialPlans = (() => {
+    if (!initialPlans) {
+      return undefined
+    }
+
+    try {
+      return pricingPlanSchema.array().parse(initialPlans)
+    } catch (error) {
+      console.error('Invalid initial pricing plans provided:', error)
+      return undefined
+    }
+  })()
+
+  return useQuery<PricingPlan[]>({
+    queryKey: [QUERY_KEYS.PRICING_PLANS, teamId],
+    queryFn: async () => {
+      if (!teamId) {
+        throw new Error('Team ID is required to fetch pricing plans')
+      }
+
+      const response = await getPricingPlans(teamId)
+      return pricingPlanSchema.array().parse(response.data)
+    },
+    enabled: Boolean(teamId),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    initialData: safeInitialPlans,
+  })
+}
+
+export const useCurrentTeamPlan = (teamId?: string, initialPlans?: PricingPlan[]) => {
+  const query = useTeamPricingPlans(teamId, initialPlans)
+
+  const currentPlan = useMemo(() => {
+    const plans = query.data ?? []
+
+    const activePlan = plans.find((plan) => plan.is_default)
+
+    if (activePlan) {
+      return activePlan
+    }
+
+    return plans.length > 0 ? plans[0] : undefined
+  }, [query.data])
+
+  return {
+    ...query,
+    plans: query.data ?? [],
+    currentPlan,
+  }
+}

--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_schemas/plans.schema.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_schemas/plans.schema.ts
@@ -8,9 +8,16 @@ export const pricingPlanSchema = z.object({
   description: z.string(),
   price: z.union([z.string(), z.number()]),
   detail: z.array(z.string()),
-  discount: z.string().optional(),
-  commission: z.string().optional(),
+  discount: z.union([z.string(), z.number()]).optional(),
+  commission: z.union([z.string(), z.number()]).optional(),
   is_default: z.boolean().optional(),
 })
 
+export const pricingPlansResponseSchema = z.object({
+  statusCode: z.number(),
+  data: z.array(pricingPlanSchema),
+  message: z.string(),
+})
+
 export type PricingPlan = z.infer<typeof pricingPlanSchema>
+export type PricingPlansResponse = z.infer<typeof pricingPlansResponseSchema>

--- a/src/app/[locale]/(back-office)/team/[teamId]/settings/_servers/plans.actions.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/settings/_servers/plans.actions.ts
@@ -2,14 +2,18 @@
 
 import { api } from '@/lib/api/config/axios-server'
 import { revalidateTag } from 'next/cache'
-import { PricingPlan } from '../_schemas/plans.schema'
+import { pricingPlansResponseSchema, type PricingPlansResponse } from '../_schemas/plans.schema'
 
-export const getPricingPlans = async (teamId: String, data: PricingPlan) => {
+export const getPricingPlans = async (teamId: string): Promise<PricingPlansResponse> => {
   try {
     const result = await api.get(`/package/team/${teamId}`)
+    const parsedResult = pricingPlansResponseSchema.parse(result.data)
+
     revalidateTag('team-plans')
-    return result.data
+
+    return parsedResult
   } catch (err) {
     console.error('Error fetching pricing plans:', err)
+    throw err
   }
 }

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -169,4 +169,5 @@ export const QUERY_KEYS = {
   BANK_LISTS: ['bank_lists'],
   REVENUE_BALANCE: ['revenue_balance'],
   PAYOUT: ['payout'],
+  PRICING_PLANS: ['pricing_plans'],
 } as const


### PR DESCRIPTION
## Summary
- add schema and server action typing for pricing plans and expose a query key
- create React Query hooks for loading team pricing plans and the active plan
- wire the upgrade settings page and pricing UI to fetch real plans and show all options

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d25fec7360832eb4a24a6556b9888e