### PR TITLE
feat: add duplicate status option for member price groups

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/price-group-form.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/price-group-form.tsx
@@ -21,9 +21,11 @@ export type PriceType = 'PER_KWH' | 'PER_MINUTE' | 'PEAK' | 'free'
 export type StatusType = 'GENERAL' | 'MEMBER'
 export type Mode = 'add' | 'edit'
 
+export type FormStatus = 'publish' | 'draft' | 'duplicate'
+
 export interface FormData {
   groupName: string
-  status: string
+  status: FormStatus
 }
 
 export interface PriceFormData {
@@ -84,9 +86,16 @@ export default function PriceGroupForm({
   const [priceType, setPriceType] = useState<PriceType>(initialData?.priceType || 'PER_KWH')
 
   // Main form state
+  const getDefaultStatus = (): FormStatus => {
+    if (initialData?.form?.status) {
+      return initialData.form.status
+    }
+    return statusType === 'MEMBER' ? 'duplicate' : 'publish'
+  }
+
   const [form, setForm] = useState<FormData>({
     groupName: initialData?.form?.groupName || '',
-    status: initialData?.form?.status || 'publish',
+    status: getDefaultStatus(),
   })
 
   // Price-specific form state
@@ -184,7 +193,7 @@ export default function PriceGroupForm({
   }
 
   const handleStatusChange = (value: string) => {
-    setForm({ ...form, status: value })
+    setForm({ ...form, status: value as FormStatus })
   }
 
   const handlePriceTypeChange = (value: string) => {
@@ -379,11 +388,7 @@ export default function PriceGroupForm({
                     >
                       Status <span className="text-destructive">*</span>
                     </Label>
-                    <Select
-                      value={form.status}
-                      onValueChange={handleStatusChange}
-                      defaultValue="publish"
-                    >
+                    <Select value={form.status} onValueChange={handleStatusChange}>
                       <SelectTrigger
                         className={`mt-2 border-none bg-[#F2F2F2] ${
                           form.status ? 'text-[#CACACA]' : 'text-oc-title-secondary'
@@ -394,6 +399,9 @@ export default function PriceGroupForm({
                       <SelectContent>
                         <SelectItem value="publish">Publish</SelectItem>
                         <SelectItem value="draft">Draft</SelectItem>
+                        {statusType === 'MEMBER' && (
+                          <SelectItem value="duplicate">Duplicate</SelectItem>
+                        )}
                       </SelectContent>
                     </Select>
                   </div>


### PR DESCRIPTION
## Summary
- introduce a dedicated `FormStatus` type that now includes a `duplicate` state for member price groups
- default member price groups to the `duplicate` status when no initial status is provided
- expose a "Duplicate" option in the status selector that appears when editing member price groups

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3a9512fc8832e905c2778228e5d69