### PR TITLE
feat: add member price group form component

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/index.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/index.ts
@@ -1,4 +1,5 @@
 export { default as PriceGroupForm } from './price-group-form'
+export { default as MemberPriceGroupForm } from './member-price-group-form'
 export type {
   FeeFormData,
   FormData,

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/member-price-group-form.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/member-price-group-form.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import PriceGroupForm from './price-group-form'
+import type { PriceGroupFormProps } from './price-group-form'
+
+export type {
+  FeeFormData,
+  FormData,
+  Mode,
+  PriceFormData,
+  PriceType,
+  StatusType,
+} from './price-group-form'
+
+export type MemberPriceGroupFormProps = Omit<PriceGroupFormProps, 'statusType'>
+
+export default function MemberPriceGroupForm(props: MemberPriceGroupFormProps) {
+  return <PriceGroupForm {...props} statusType="MEMBER" />
+}


### PR DESCRIPTION
## Summary
- add a dedicated member price group form wrapper component
- export the new member form from the forms index for reuse

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3af015dcc832ea83c45b30f575ce1