### PR TITLE
refactor: centralize price group form schemas

### DIFF
--- a/src/components/back-office/team/form/price-groups/_schemas/price-group.ts
+++ b/src/components/back-office/team/form/price-groups/_schemas/price-group.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+
+export const priceTypeSchema = z.enum(['PER_KWH', 'PER_MINUTE', 'PEAK', 'free'])
+export type PriceType = z.infer<typeof priceTypeSchema>
+
+export const statusTypeSchema = z.enum(['GENERAL', 'MEMBER'])
+export type StatusType = z.infer<typeof statusTypeSchema>
+
+export const modeSchema = z.enum(['add', 'edit'])
+export type Mode = z.infer<typeof modeSchema>
+
+export const formSchema = z.object({
+  groupName: z.string().min(1, 'Group name is required'),
+  status: z.string(),
+})
+export type FormData = z.infer<typeof formSchema>
+
+export const priceFormSchema = z.object({
+  pricePerKwh: z.string(),
+  pricePerKwhMinute: z.string(),
+  price_per_minute: z.string(),
+  onPeakPrice: z.string(),
+  offPeakPrice: z.string(),
+  freeKw: z.string(),
+  freeKwh: z.string(),
+})
+export type PriceFormData = z.infer<typeof priceFormSchema>
+
+export const feeFormSchema = z.object({
+  startingFeeDescription: z.string(),
+  fee: z.string(),
+  chargingFeeDescription: z.string(),
+  feePrice: z.string(),
+  applyAfterMinute: z.string(),
+  minuteFeeDescription: z.string(),
+  feePerMin: z.string(),
+  applyFeeAfterMinute: z.string(),
+  feeStopsAfterMinute: z.string(),
+  idleFeeDescription: z.string(),
+  feePerMinIdle: z.string(),
+  timeBeforeIdleFeeApplied: z.string(),
+  maxTotalIdleFee: z.string(),
+})
+export type FeeFormData = z.infer<typeof feeFormSchema>
+
+export const priceGroupSubmissionSchema = z.object({
+  form: formSchema,
+  priceForm: priceFormSchema,
+  feeForm: feeFormSchema,
+  priceType: priceTypeSchema,
+})
+export type PriceGroupSubmissionData = z.infer<typeof priceGroupSubmissionSchema>
+
+export const priceGroupFormInitialDataSchema = z.object({
+  form: formSchema.partial().optional(),
+  priceForm: priceFormSchema.partial().optional(),
+  feeForm: feeFormSchema.partial().optional(),
+  priceType: priceTypeSchema.optional(),
+})
+export type PriceGroupFormInitialData = z.infer<typeof priceGroupFormInitialDataSchema>
+
+export interface PriceGroupFormProps {
+  mode: Mode
+  statusType: StatusType
+  initialData?: PriceGroupFormInitialData
+  isLoading?: boolean
+  onSubmit: (data: PriceGroupSubmissionData) => Promise<void>
+  onBack: () => void
+  teamGroupId?: string | null
+}

--- a/src/components/back-office/team/form/price-groups/index.ts
+++ b/src/components/back-office/team/form/price-groups/index.ts
@@ -1,10 +1,22 @@
 export { default as PriceGroupForm } from './price-group-form'
+export {
+  feeFormSchema,
+  formSchema,
+  modeSchema,
+  priceFormSchema,
+  priceGroupFormInitialDataSchema,
+  priceGroupSubmissionSchema,
+  priceTypeSchema,
+  statusTypeSchema,
+} from './_schemas/price-group'
 export type {
   FeeFormData,
   FormData,
   Mode,
   PriceFormData,
+  PriceGroupFormInitialData,
   PriceGroupFormProps,
+  PriceGroupSubmissionData,
   PriceType,
   StatusType,
-} from './price-group-form'
+} from './_schemas/price-group'


### PR DESCRIPTION
## Summary
- add a shared Zod schema file for price group form data and props
- update the price group form to rely on the shared schemas for typing and validation
- expose the schemas and derived types through the price group form index for reuse

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b40e4c08832eafce218f4c30360e