### PR TITLE
Add billing day field to price group initial data

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_schemas/price-group-form.schema.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_schemas/price-group-form.schema.ts
@@ -107,6 +107,7 @@ export interface PriceGroupFormInitialData {
   priceForm?: Partial<PriceFormData>
   feeForm?: Partial<FeeFormData>
   priceType?: PriceType
+  billingDay?: number | string | null
 }
 
 export interface PriceGroupFormProps {


### PR DESCRIPTION
## Summary
- extend `PriceGroupFormInitialData` with an optional `billingDay` field so member price group forms can safely use the value
- accept the Next.js generated reference update in `next-env.d.ts`

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d41a87a8f4832e9035d8f097d0fd5d