### PR TITLE
Conditionally render usage billing price form

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/memeber-price/edit-member-price-group.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/edit/memeber-price/edit-member-price-group.tsx
@@ -76,6 +76,7 @@ export default function EditMemberPriceGroup() {
         maxTotalIdleFee: toStringSafe(priceGroup.idle_fee?.max_total_idle_fee),
       },
       priceType: castedPriceType,
+      billingType: priceGroup.type === 'TIERED_CREDIT' ? 'CREDIT' : 'USAGE',
     }
   }, [priceGroup])
 
@@ -215,6 +216,7 @@ export default function EditMemberPriceGroup() {
         isLoading={isLoading}
         onSubmit={handleSubmit}
         onBack={handleBack}
+        billingType={initialData?.billingType ?? 'USAGE'}
       />
 
       <SuccessDialog

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/index.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/index.ts
@@ -1,6 +1,7 @@
 export { default as MemberPriceGroupForm } from './member-price-group-form'
 export { default as PriceGroupForm } from './price-group-form'
 export type {
+  BillingType,
   FeeFormData,
   FormData,
   Mode,
@@ -12,6 +13,7 @@ export type {
 } from '../../_schemas/price-group-form.schema'
 export {
   PriceGroupFormSubmissionSchema,
+  BillingTypeSchema,
   FeeFormSchema,
   FormSchema,
   PriceFormSchema,

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/price-group-form.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_components/forms/price-group-form.tsx
@@ -13,6 +13,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { toast } from '@/hooks/use-toast'
+import { cn } from '@/lib/utils'
 import { ChevronLeft, Loader2 } from 'lucide-react'
 import React, { useEffect, useState } from 'react'
 
@@ -36,7 +37,10 @@ export default function PriceGroupForm({
   onSubmit,
   onBack,
   teamGroupId,
+  billingType,
 }: PriceGroupFormProps) {
+  const resolvedBillingType = billingType ?? initialData?.billingType ?? 'USAGE'
+  const isUsageBilling = resolvedBillingType === 'USAGE'
   const [priceType, setPriceType] = useState<PriceType>(initialData?.priceType ?? 'PER_KWH')
 
   // Main form state
@@ -286,7 +290,10 @@ export default function PriceGroupForm({
               <div className="flex flex-col lg:flex-row">
                 {/* Left Column - Form inputs */}
                 <div
-                  className="flex flex-1 flex-col gap-6 border-b pb-6 pt-6 md:pb-0 md:pt-8 lg:w-1/4 lg:flex-none lg:border-b-0 lg:border-r lg:pr-8"
+                  className={cn(
+                    'flex flex-1 flex-col gap-6 border-b pb-6 pt-6 md:pb-0 md:pt-8 lg:flex-none',
+                    isUsageBilling ? 'lg:w-1/4 lg:border-b-0 lg:border-r lg:pr-8' : 'lg:w-full lg:border-b-0',
+                  )}
                   style={{ minHeight: 'max(300px, 100%)' }}
                 >
                   <div>
@@ -332,25 +339,26 @@ export default function PriceGroupForm({
                 </div>
 
                 {/* Right Column - Form inputs */}
-                <div className="flex-1 space-y-6 px-4 pb-6 pt-6 md:px-4 md:pb-8 md:pt-8 lg:w-3/4 lg:pl-8 lg:pr-0">
-                  {/* Price Type Selection */}
-                  <div>
-                    <Label className="text-oc-title-secondary text-base font-semibold">
-                      การตั้งรูปแบบราคา <span className="text-destructive">*</span>
-                    </Label>
-                    <div className="mt-3 flex flex-wrap gap-3 rounded-lg bg-[#355FF5] p-4">
-                      <RadioGroup
-                        value={priceType}
-                        onValueChange={handlePriceTypeChange}
-                        className="flex w-full flex-wrap gap-6"
-                      >
-                        <div
-                          className={`flex items-center space-x-2 rounded-xl px-6 py-3 transition-colors ${
-                            priceType === 'PER_KWH'
-                              ? 'bg-white/20 text-white'
-                              : 'bg-[#2B58F7] text-white'
-                          }`}
+                {isUsageBilling && (
+                  <div className="flex-1 space-y-6 px-4 pb-6 pt-6 md:px-4 md:pb-8 md:pt-8 lg:w-3/4 lg:pl-8 lg:pr-0">
+                    {/* Price Type Selection */}
+                    <div>
+                      <Label className="text-oc-title-secondary text-base font-semibold">
+                        การตั้งรูปแบบราคา <span className="text-destructive">*</span>
+                      </Label>
+                      <div className="mt-3 flex flex-wrap gap-3 rounded-lg bg-[#355FF5] p-4">
+                        <RadioGroup
+                          value={priceType}
+                          onValueChange={handlePriceTypeChange}
+                          className="flex w-full flex-wrap gap-6"
                         >
+                          <div
+                            className={`flex items-center space-x-2 rounded-xl px-6 py-3 transition-colors ${
+                              priceType === 'PER_KWH'
+                                ? 'bg-white/20 text-white'
+                                : 'bg-[#2B58F7] text-white'
+                            }`}
+                          >
                           <RadioGroupItem
                             value="PER_KWH"
                             id="radio-kwh"
@@ -1013,6 +1021,7 @@ export default function PriceGroupForm({
                     </div>
                   )}
                 </div>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_schemas/price-group-form.schema.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/price-groups/_schemas/price-group-form.schema.ts
@@ -12,6 +12,9 @@ const trimmedInput = z
 export const PriceTypeSchema = z.enum(['PER_KWH', 'PER_MINUTE', 'PEAK', 'free', 'TIERED_CREDIT'])
 export type PriceType = z.infer<typeof PriceTypeSchema>
 
+export const BillingTypeSchema = z.enum(['USAGE', 'CREDIT'])
+export type BillingType = z.infer<typeof BillingTypeSchema>
+
 export const StatusTypeSchema = z.enum(['GENERAL', 'MEMBER'])
 export type StatusType = z.infer<typeof StatusTypeSchema>
 
@@ -101,6 +104,7 @@ export interface PriceGroupFormInitialData {
   feeForm?: Partial<FeeFormData>
   priceType?: PriceType
   billingDay?: number | string | null
+  billingType?: BillingType | null
 }
 
 export interface PriceGroupFormProps {
@@ -111,4 +115,5 @@ export interface PriceGroupFormProps {
   onSubmit: (data: PriceGroupFormSubmission) => Promise<void>
   onBack: () => void
   teamGroupId?: string | null
+  billingType?: BillingType
 }


### PR DESCRIPTION
## Summary
- extend the price group form schema to support billing type metadata
- render the price configuration UI only when the billing type is usage-driven and adjust layout accordingly
- pass the derived billing type into the member price group edit flow so credit-based groups skip the usage form

## Testing
- pnpm lint:check

------
https://chatgpt.com/codex/tasks/task_e_68d50e88ad28832e91846d7f299f5c2d