### PR TITLE
Fetch team wallet balance from API

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/team-wallet-tab.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/team-wallet-tab.tsx
@@ -1,3 +1,4 @@
+
 'use client'
 
 import { Separator } from '@/components/ui/separator'
@@ -14,6 +15,7 @@ interface TeamWalletTabProps {
   chargeSessions: ChargeSession[]
   searchQuery: string
   onSearchChange: (value: string) => void
+  isWalletLoading?: boolean
 }
 
 export function TeamWalletTab({
@@ -22,11 +24,12 @@ export function TeamWalletTab({
   chargeSessions,
   searchQuery,
   onSearchChange,
+  isWalletLoading = false,
 }: TeamWalletTabProps) {
   return (
     <>
       <div className="mt-4 flex items-stretch gap-4">
-        <WalletCard walletBalance={walletBalance} teamId={teamId} />
+        <WalletCard walletBalance={walletBalance} teamId={teamId} isLoading={isWalletLoading} />
         <TopUpCard />
       </div>
 

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/wallet-card.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/wallet-card.tsx
@@ -1,3 +1,4 @@
+
 'use client'
 
 import { TeamWalletIcon } from '@/components/icons/TeamWalletIcon'
@@ -6,9 +7,16 @@ import Image from 'next/image'
 interface WalletCardProps {
   walletBalance: number
   teamId: string
+  isLoading?: boolean
 }
 
-export function WalletCard({ walletBalance, teamId }: WalletCardProps) {
+export function WalletCard({ walletBalance, teamId, isLoading = false }: WalletCardProps) {
+  const safeBalance = Number.isFinite(walletBalance) ? walletBalance : 0
+  const formattedBalance = safeBalance.toLocaleString('th-TH', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+
   return (
     <div className="relative h-44 w-full max-w-xs overflow-hidden rounded-2xl">
       <Image
@@ -28,7 +36,13 @@ export function WalletCard({ walletBalance, teamId }: WalletCardProps) {
           </div>
         </div>
         <div className="mt-6">
-          <div className="text-3xl font-bold">{walletBalance.toLocaleString()} ฿</div>
+          <div className="text-3xl font-bold">
+            {isLoading ? (
+              <div className="h-8 w-40 animate-pulse rounded-full bg-white/40" />
+            ) : (
+              `${formattedBalance} ฿`
+            )}
+          </div>
           <div className="text-xs font-light">Team ID : {teamId}</div>
         </div>
       </div>

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_hooks/use-team-wallet-mutation.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_hooks/use-team-wallet-mutation.ts
@@ -1,0 +1,23 @@
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { QUERY_KEYS } from '@/lib/constants'
+
+import {
+  refreshTeamWalletBalance,
+  type RefreshTeamWalletBalanceVariables,
+} from '../_services/TeamWalletMutation'
+import type { TeamWalletBalanceResponse } from '../_services/TeamWalletQuery'
+
+const useTeamWalletMutation = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<TeamWalletBalanceResponse, Error, RefreshTeamWalletBalanceVariables>({
+    mutationFn: refreshTeamWalletBalance,
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData([...QUERY_KEYS.TEAM_WALLET, variables.teamGroupId], data)
+    },
+  })
+}
+
+export { useTeamWalletMutation }

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_hooks/use-team-wallet-query.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_hooks/use-team-wallet-query.ts
@@ -1,0 +1,28 @@
+
+import { useQuery } from '@tanstack/react-query'
+
+import { QUERY_KEYS } from '@/lib/constants'
+
+import { fetchTeamWalletBalance } from '../_services/TeamWalletQuery'
+import type { TeamWalletBalanceResponse } from '../_services/TeamWalletQuery'
+
+const STALE_TIME = 60 * 1000 // 1 minute
+const GC_TIME = 5 * 60 * 1000 // 5 minutes
+
+const useTeamWalletQuery = (teamGroupId?: string | number) => {
+  return useQuery<TeamWalletBalanceResponse, Error>({
+    queryKey: [...QUERY_KEYS.TEAM_WALLET, teamGroupId ?? null],
+    queryFn: () => {
+      if (teamGroupId === undefined || teamGroupId === null || teamGroupId === '') {
+        throw new Error('A valid team group id is required to fetch team wallet balance')
+      }
+
+      return fetchTeamWalletBalance(teamGroupId)
+    },
+    enabled: teamGroupId !== undefined && teamGroupId !== null && teamGroupId !== '',
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  })
+}
+
+export { useTeamWalletQuery }

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_layers/presentation/team-wallet-page.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_layers/presentation/team-wallet-page.tsx
@@ -1,16 +1,17 @@
+
 'use client'
 
 import { TeamHeader } from '@/app/[locale]/(back-office)/team/_components/team-header'
 import { TeamTabMenu } from '@/app/[locale]/(back-office)/team/_components/team-tab-menu'
 import { useI18n } from '@/lib/i18n'
+import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
-import { useState } from 'react'
 
 import {
   chargeCardsMock,
   chargeSessionsMock,
-  walletBalanceMock,
 } from '../../mock/team-wallet.mock'
+import { useTeamWalletQuery } from '../../_hooks/use-team-wallet-query'
 import { ChargeCard, ChargeSession } from '../../_schemas/team-wallet.schema'
 import { ChargeCardsTab } from '../../_components/team-wallet/charge-cards-tab'
 import { Pagination } from '../../_components/team-wallet/pagination'
@@ -29,7 +30,19 @@ export function TeamWalletPage({ teamId }: TeamWalletPageProps) {
   const [activeSubTab, setActiveSubTab] = useState<TeamWalletSubTab>('team-wallet')
   const [searchQuery, setSearchQuery] = useState('')
 
-  const walletBalance = walletBalanceMock
+  const {
+    data: teamWallet,
+    isLoading: isWalletLoading,
+    error: walletError,
+  } = useTeamWalletQuery(teamId)
+
+  useEffect(() => {
+    if (walletError) {
+      console.error('[TeamWalletPage] Failed to fetch team wallet balance', walletError)
+    }
+  }, [walletError])
+
+  const walletBalance = teamWallet?.data.walletBalance ?? 0
   const chargeSessions: ChargeSession[] = chargeSessionsMock
   const chargeCards: ChargeCard[] = chargeCardsMock
 
@@ -74,6 +87,7 @@ export function TeamWalletPage({ teamId }: TeamWalletPageProps) {
               <TeamWalletTab
                 teamId={teamId}
                 walletBalance={walletBalance}
+                isWalletLoading={isWalletLoading}
                 chargeSessions={chargeSessions}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_schemas/team-wallet.schema.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_schemas/team-wallet.schema.ts
@@ -1,3 +1,4 @@
+
 import { z } from 'zod'
 
 export const ChargeSessionSchema = z.object({
@@ -36,3 +37,16 @@ export const TeamWalletSchema = z.object({
 })
 
 export type TeamWalletData = z.infer<typeof TeamWalletSchema>
+
+export const TeamWalletBalanceDataSchema = z.object({
+  walletBalance: WalletBalanceSchema,
+})
+
+export const TeamWalletBalanceResponseSchema = z.object({
+  statusCode: z.number().optional(),
+  message: z.string().optional(),
+  data: TeamWalletBalanceDataSchema,
+})
+
+export type TeamWalletBalanceData = z.infer<typeof TeamWalletBalanceDataSchema>
+export type TeamWalletBalanceResponse = z.infer<typeof TeamWalletBalanceResponseSchema>

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_services/TeamWalletMutation.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_services/TeamWalletMutation.ts
@@ -1,0 +1,15 @@
+
+import { fetchTeamWalletBalance } from './TeamWalletQuery'
+
+interface RefreshTeamWalletBalanceVariables {
+  teamGroupId: string | number
+}
+
+const refreshTeamWalletBalance = async ({
+  teamGroupId,
+}: RefreshTeamWalletBalanceVariables) => {
+  return fetchTeamWalletBalance(teamGroupId)
+}
+
+export { refreshTeamWalletBalance }
+export type { RefreshTeamWalletBalanceVariables }

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_services/TeamWalletQuery.ts
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_services/TeamWalletQuery.ts
@@ -1,0 +1,118 @@
+
+import { api } from '@/lib/api/config/axios-client'
+import { API_ENDPOINTS } from '@/lib/constants'
+
+import {
+  TeamWalletBalanceResponse,
+  TeamWalletBalanceResponseSchema,
+} from '../_schemas/team-wallet.schema'
+
+const buildTeamWalletBalanceUrl = (teamGroupId: string | number) =>
+  API_ENDPOINTS.TEAM_GROUPS.WALLET.BALANCE.replace(
+    '{team_group_id}',
+    encodeURIComponent(String(teamGroupId)),
+  )
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const extractWalletBalance = (payload: unknown): number | undefined => {
+  if (typeof payload === 'number' && Number.isFinite(payload)) {
+    return payload
+  }
+
+  if (!isRecord(payload)) {
+    return undefined
+  }
+
+  const directCandidates = [
+    payload['walletBalance'],
+    payload['wallet_balance'],
+    payload['balance'],
+    payload['amount'],
+  ]
+
+  for (const candidate of directCandidates) {
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return candidate
+    }
+  }
+
+  if ('data' in payload) {
+    const nested = extractWalletBalance(payload['data'])
+    if (typeof nested === 'number') {
+      return nested
+    }
+  }
+
+  if ('result' in payload) {
+    const nested = extractWalletBalance(payload['result'])
+    if (typeof nested === 'number') {
+      return nested
+    }
+  }
+
+  return undefined
+}
+
+const normalizeTeamWalletBalanceResponse = (raw: unknown) => {
+  const walletBalance = extractWalletBalance(raw)
+
+  if (walletBalance === undefined) {
+    throw new Error('Invalid wallet balance response structure')
+  }
+
+  const record = isRecord(raw) ? raw : {}
+  const statusCode = typeof record['statusCode'] === 'number' ? record['statusCode'] : 200
+  const message = typeof record['message'] === 'string' ? record['message'] : undefined
+
+  return {
+    ...(Number.isFinite(statusCode) ? { statusCode } : {}),
+    ...(message ? { message } : {}),
+    data: {
+      walletBalance,
+    },
+  }
+}
+
+const logApiError = (action: string, error: unknown, context: Record<string, unknown>) => {
+  console.error(`[TeamWalletQuery] ${action}`, {
+    error,
+    ...context,
+    timestamp: new Date().toISOString(),
+    errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    errorStack: error instanceof Error ? error.stack : undefined,
+  })
+}
+
+const fetchTeamWalletBalance = async (
+  teamGroupId: string | number,
+): Promise<TeamWalletBalanceResponse> => {
+  if (teamGroupId === undefined || teamGroupId === null || teamGroupId === '') {
+    throw new Error('A valid team group id is required to fetch team wallet balance')
+  }
+
+  try {
+    const endpoint = buildTeamWalletBalanceUrl(teamGroupId)
+    const raw = await api.get<unknown>(endpoint)
+    const normalized = normalizeTeamWalletBalanceResponse(raw)
+    const parsed = TeamWalletBalanceResponseSchema.parse(normalized)
+
+    if (parsed.statusCode !== undefined && parsed.statusCode !== 200) {
+      throw new Error(parsed.message || 'Failed to fetch team wallet balance')
+    }
+
+    return parsed
+  } catch (error) {
+    logApiError('Failed to fetch team wallet balance', error, { teamGroupId })
+
+    if (error instanceof Error) {
+      throw error
+    }
+
+    throw new Error('Failed to fetch team wallet balance')
+  }
+}
+
+export { fetchTeamWalletBalance }
+export type { TeamWalletBalanceResponse }

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -103,6 +103,9 @@ export const API_ENDPOINTS = {
         CONFIRM: '/partner/revenue/payout/confirm',
       },
     },
+    WALLET: {
+      BALANCE: '/wallet/team/{team_group_id}',
+    },
   },
 } as const
 
@@ -171,4 +174,5 @@ export const QUERY_KEYS = {
   REVENUE_BALANCE: ['revenue_balance'],
   PAYOUT: ['payout'],
   PRICING_PLANS: ['pricing_plans'],
+  TEAM_WALLET: ['team_wallet'],
 } as const


### PR DESCRIPTION
## Summary
- add axios service and react-query hooks to retrieve team wallet balance using the new wallet endpoint
- wire the team wallet page and wallet card to the query data with a loading state and schema validation
- register wallet API constants and query keys for reuse across hooks and mutations

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68dc27352c7c832eae5beec19883638a