### PR TITLE
refactor: use shared data table for team wallet sessions

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-sessions-table.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-sessions-table.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
+import { DataTable, TableColumn } from '@/components/ui/data-table'
 
 import { ChargeSession } from '../../_schemas/team-wallet.schema'
 
@@ -8,107 +9,114 @@ interface ChargeSessionsTableProps {
   sessions: ChargeSession[]
 }
 
+type ChargeSessionRow = ChargeSession & Record<string, string>
+
+const columns: TableColumn<ChargeSessionRow>[] = [
+  {
+    key: 'orderNumber',
+    header: 'ORDER NUMBER',
+    align: 'center',
+    width: '16%',
+    render: (_, row) => (
+      <div className="flex flex-col items-center">
+        <span className="text-xs font-medium text-oc-sidebar">{row.orderNumber}</span>
+        <span className="text-xs text-muted-foreground">{row.location}</span>
+      </div>
+    ),
+  },
+  {
+    key: 'station',
+    header: 'CHARGING STATION',
+    align: 'center',
+    width: '12%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'charger',
+    header: 'CHARGER',
+    align: 'center',
+    width: '10%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'rate',
+    header: 'RATE',
+    align: 'center',
+    width: '8%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'startCharge',
+    header: 'START CHARGE',
+    align: 'center',
+    width: '12%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'stopCharge',
+    header: 'STOP CHARGE',
+    align: 'center',
+    width: '12%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'time',
+    header: 'TIME',
+    align: 'center',
+    width: '8%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'kWh',
+    header: 'KWH',
+    align: 'center',
+    width: '6%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'revenue',
+    header: 'REVENUE',
+    align: 'center',
+    width: '10%',
+    render: (value) => <span className="text-xs text-oc-sidebar">{value}</span>,
+  },
+  {
+    key: 'status',
+    header: 'STATUS',
+    align: 'center',
+    width: '10%',
+    render: (value) => (
+      <span className="inline-flex rounded-md bg-[#DFF8F3] px-2 py-1 text-xs font-semibold leading-5 text-[#0D8A72]">
+        {value}
+      </span>
+    ),
+  },
+  {
+    key: 'action',
+    header: 'ACTION',
+    align: 'center',
+    width: '8%',
+    render: () => (
+      <Button variant="ghost" size="sm" className="h-6 w-6 p-0 hover:bg-gray-100">
+        <svg width="10" height="10" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M9.38318 0C9.80871 0 10.2166 0.169903 10.5145 0.47017L12.5299 2.48552C12.8299 2.78558 12.9985 3.19254 12.9985 3.61688C12.9985 4.04122 12.83 4.44819 12.5299 4.74824L5.17178 12.104C4.71782 12.6277 4.07431 12.9494 3.3371 13H0V12.3501L0.00211073 9.61063C0.0574781 8.9253 0.37609 8.28805 0.862122 7.85981L8.25104 0.470954C8.55066 0.169519 8.95813 0 9.38318 0ZM3.29214 11.6988C3.63934 11.6742 3.96254 11.5126 4.22206 11.2158L9.13528 6.30255L6.69522 3.8624L1.75328 8.80323C1.48988 9.03612 1.32698 9.36194 1.30078 9.65999V11.6976L3.29214 11.6988ZM7.61446 2.94338L10.0544 5.38342L11.6117 3.82613C11.668 3.76985 11.6996 3.69351 11.6996 3.61391C11.6996 3.53431 11.668 3.45797 11.6117 3.40168L9.59455 1.38452C9.53889 1.32843 9.46314 1.29688 9.38412 1.29688C9.3051 1.29688 9.22935 1.32843 9.17369 1.38452L7.61446 2.94338Z"
+            fill="#818894"
+          />
+        </svg>
+      </Button>
+    ),
+  },
+]
+
 export function ChargeSessionsTable({ sessions }: ChargeSessionsTableProps) {
+  const tableData = sessions.map((session) => ({ ...session })) as ChargeSessionRow[]
+
   return (
-    <div className="mt-4 overflow-x-auto">
-      <table className="min-w-full border-separate border-spacing-y-4">
-        <thead className="rounded-lg bg-primary">
-          <tr>
-            <th className="rounded-tl-lg px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              ORDER NUMBER
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              CHARGING STATION
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              CHARGER
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              RATE
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              START CHARGE
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              STOP CHARGE
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              TIME
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              KWH
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              REVENUE
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              STATUS
-            </th>
-            <th className="rounded-tr-lg px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              ACTION
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {sessions.map((session, index) => (
-            <tr key={index} className="shadow-xs rounded-lg bg-background">
-              <td className="whitespace-nowrap rounded-l-lg px-2 py-2 text-center md:px-4 md:py-3">
-                <div>
-                  <div className="text-oc-sidebar text-xs font-medium">{session.orderNumber}</div>
-                  <div className="text-xs text-muted-foreground">{session.location}</div>
-                </div>
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.station}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.charger}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.rate}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.startCharge}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.stopCharge}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.time}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.kWh}
-              </td>
-              <td className="text-oc-sidebar whitespace-nowrap px-2 py-2 text-center text-xs md:px-4 md:py-3">
-                {session.revenue}
-              </td>
-              <td className="whitespace-nowrap px-2 py-2 text-center md:px-4 md:py-3">
-                <span className="inline-flex rounded-md bg-[#DFF8F3] px-2 py-1 text-xs font-semibold leading-5 text-[#0D8A72]">
-                  {session.status}
-                </span>
-              </td>
-              <td className="whitespace-nowrap rounded-r-lg px-1 py-1 text-center text-xs text-[#818894] md:px-4 md:py-3">
-                <Button variant="ghost" size="sm" className="h-6 w-6 p-0 hover:bg-gray-100">
-                  <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 13 13"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      clipRule="evenodd"
-                      d="M9.38318 0C9.80871 0 10.2166 0.169903 10.5145 0.47017L12.5299 2.48552C12.8299 2.78558 12.9985 3.19254 12.9985 3.61688C12.9985 4.04122 12.83 4.44819 12.5299 4.74824L5.17178 12.104C4.71782 12.6277 4.07431 12.9494 3.3371 13H0V12.3501L0.00211073 9.61063C0.0574781 8.9253 0.37609 8.28805 0.862122 7.85981L8.25104 0.470954C8.55066 0.169519 8.95813 0 9.38318 0ZM3.29214 11.6988C3.63934 11.6742 3.96254 11.5126 4.22206 11.2158L9.13528 6.30255L6.69522 3.8624L1.7532 8.80323C1.48988 9.03612 1.32698 9.36194 1.30078 9.65999V11.6976L3.29214 11.6988ZM7.61446 2.94338L10.0544 5.38342L11.6117 3.82613C11.668 3.76985 11.6996 3.69351 11.6996 3.61391C11.6996 3.53431 11.668 3.45797 11.6117 3.40168L9.59455 1.38452C9.53889 1.32843 9.46314 1.29688 9.38412 1.29688C9.3051 1.29688 9.22935 1.32843 9.17369 1.38452L7.61446 2.94338Z"
-                      fill="#818894"
-                    />
-                  </svg>
-                </Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+    <div className="mt-4">
+      <DataTable data={tableData} columns={columns} className="border-0 shadow-none" />
     </div>
   )
 }

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/table-header.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/table-header.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { ChevronDown, Search } from 'lucide-react'
 
 interface TableHeaderProps {
   searchQuery: string
@@ -25,20 +26,7 @@ export function TableHeader({
             className="h-10 bg-[#ECF2F8] pl-4 pr-10 placeholder:font-medium placeholder:text-[#A1B1D1]"
           />
           <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-            <svg
-              className="h-4 w-4 text-[#A1B1D1]"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
+            <Search className="h-4 w-4 text-[#A1B1D1]" />
           </div>
         </div>
         <Button
@@ -47,20 +35,7 @@ export function TableHeader({
           className="h-10 gap-1 whitespace-nowrap bg-[#ECF2F8] text-xs sm:text-sm"
         >
           <span className="text-[#A1B1D1]">Filter by Status</span>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-4 w-4 text-[#A1B1D1]"
-          >
-            <path d="m6 9 6 6 6-6" />
-          </svg>
+          <ChevronDown className="h-4 w-4 text-[#A1B1D1]" />
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the bespoke charge session markup with the shared shadcn data table so the view can scale across many records
- refresh the table header controls to use shared lucide icons alongside the reusable table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc30d2fe90832e99da6d4f823533a5