### PR TITLE
Restyle charge cards table with shadcn data table

### DIFF
--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-cards-tab.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-cards-tab.tsx
@@ -1,9 +1,5 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Plus } from 'lucide-react'
-
 import { ChargeCard } from '../../_schemas/team-wallet.schema'
 import { ChargeCardsTable } from './charge-cards-table'
 
@@ -14,36 +10,6 @@ interface ChargeCardsTabProps {
 export function ChargeCardsTab({ chargeCards }: ChargeCardsTabProps) {
   return (
     <div className="mt-4">
-      {/* Search and Filter Section for Charge Cards */}
-      <div className="mb-4 flex flex-col justify-between gap-3 sm:flex-row">
-        <div className="relative max-w-xs">
-          <Input
-            placeholder="Search"
-            className="h-10 bg-[#ECF2F8] pl-4 pr-10 placeholder:font-medium placeholder:text-[#A1B1D1]"
-          />
-          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
-            <svg
-              className="h-4 w-4 text-[#A1B1D1]"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
-        </div>
-        <Button className="mt h-10 text-xs sm:text-sm">
-          <Plus className="mr-1.5 h-3.5 w-3.5" />
-          ADD CARD
-        </Button>
-      </div>
-
       <ChargeCardsTable cards={chargeCards} />
     </div>
   )

--- a/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-cards-table.tsx
+++ b/src/app/[locale]/(back-office)/team/[teamId]/team-wallet/_components/team-wallet/charge-cards-table.tsx
@@ -1,85 +1,377 @@
 'use client'
 
+import * as React from 'react'
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  SortingState,
+  VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { CreditCard, MoreHorizontal } from 'lucide-react'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { CreditCard, MoreHorizontal, Plus } from 'lucide-react'
 
-import { ChargeCard } from '../../_schemas/team-wallet.schema'
+import { cn } from '@/lib/utils'
+import { type ChargeCard } from '../../_schemas/team-wallet.schema'
+
+type ChargeCardRow = ChargeCard
 
 interface ChargeCardsTableProps {
   cards: ChargeCard[]
 }
 
+const centeredColumnIds = new Set(['owner', 'accessibility', 'status', 'created', 'actions'])
+
 export function ChargeCardsTable({ cards }: ChargeCardsTableProps) {
-  return (
-    <div className="mt-2 overflow-x-auto">
-      <table className="min-w-full border-separate border-spacing-y-4">
-        <thead className="rounded-lg bg-blue-600">
-          <tr>
-            <th className="rounded-tl-lg px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              {cards.length} CHARGE CARDS
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              OWNER
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              ACCESSIBILITY
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              STATUS
-            </th>
-            <th className="px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              CREATED
-            </th>
-            <th className="rounded-tr-lg px-2 py-2 text-center text-xs font-medium uppercase tracking-wider text-white md:px-4 md:py-3">
-              ACTION
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {cards.map((card) => (
-            <tr key={card.id} className="shadow-xs rounded-lg bg-white hover:bg-gray-50">
-              <td className="whitespace-nowrap rounded-l-lg px-2 py-2 text-center md:px-4 md:py-3">
-                <div className="flex items-center justify-center">
-                  <div className="relative mr-2 flex h-8 w-8 items-center justify-center rounded-full border-2 border-[#E7E7E7] bg-card text-[#B6B6B6]">
-                    <CreditCard className="h-3.5 w-3.5" />
-                    <div className="absolute bottom-1.5 right-1 h-[9px] w-[9px] rounded-full bg-primary"></div>
-                  </div>
-                  <div>
-                    <div className="mr-3 text-xs font-medium text-[#6E82A5]">CARD {card.id}</div>
-                    <div className="text-xs text-[#818894]">ID: {card.cardId}</div>
-                  </div>
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
+  const [rowSelection, setRowSelection] = React.useState({})
+
+  const columns = React.useMemo<ColumnDef<ChargeCardRow>[]>(
+    () => [
+      {
+        id: 'select',
+        header: ({ table }) => (
+          <Checkbox
+            checked={
+              table.getIsAllPageRowsSelected() ||
+              (table.getIsSomePageRowsSelected() && 'indeterminate')
+            }
+            onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+            aria-label="Select all"
+          />
+        ),
+        cell: ({ row }) => (
+          <Checkbox
+            checked={row.getIsSelected()}
+            onCheckedChange={(value) => row.toggleSelected(!!value)}
+            aria-label="Select row"
+          />
+        ),
+        enableSorting: false,
+        enableHiding: false,
+        size: 48,
+      },
+      {
+        accessorKey: 'cardId',
+        header: () => (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {cards.length} Charge Cards
+          </span>
+        ),
+        enableSorting: false,
+        cell: ({ row }) => {
+          const card = row.original
+
+          return (
+            <div className="flex items-center gap-3">
+              <div className="relative flex h-10 w-10 items-center justify-center rounded-full border border-border bg-card text-muted-foreground">
+                <CreditCard className="h-4 w-4" />
+                <div className="absolute bottom-1.5 right-1.5 h-2 w-2 rounded-full bg-primary" />
+              </div>
+              <div>
+                <div className="text-sm font-medium uppercase tracking-wide text-[#6E82A5]">
+                  Card {card.id}
                 </div>
-              </td>
-              <td className="whitespace-nowrap px-2 py-2 text-center text-xs text-[#6E82A5] md:px-4 md:py-3">
-                {card.owner}
-              </td>
-              <td className="whitespace-nowrap px-2 py-2 text-center text-xs text-[#6E82A5] md:px-4 md:py-3">
-                {card.accessibility}
-              </td>
-              <td className="whitespace-nowrap px-2 py-2 text-center md:px-4 md:py-3">
-                <Badge
-                  className={
-                    card.status === 'Active'
-                      ? 'rounded-lg bg-[#DFF8F3] px-4 py-1 text-[#0D8A72] hover:bg-[#DFF8F3] hover:text-[#0D8A72]'
-                      : 'rounded-lg bg-[#D1E9FF] px-4 py-1 text-[#40A3FF] hover:bg-[#D1E9FF] hover:text-[#40A3FF]'
-                  }
-                >
-                  <p className="font-medium">{card.status}</p>
-                </Badge>
-              </td>
-              <td className="whitespace-pre-line px-2 py-2 text-center text-xs text-[#6E82A5] md:px-4 md:py-3">
-                {card.created}
-              </td>
-              <td className="whitespace-nowrap rounded-r-lg px-2 py-2 text-center text-xs text-gray-500 md:px-4 md:py-3">
-                <Button variant="ghost" size="sm" className="h-6 w-6 p-0 hover:bg-gray-100">
-                  <MoreHorizontal className="h-3.5 w-3.5" />
+                <div className="text-xs text-[#818894]">ID: {card.cardId}</div>
+              </div>
+            </div>
+          )
+        },
+        filterFn: (row, columnId, value) => {
+          const search = String(value).toLowerCase().trim()
+          if (!search) {
+            return true
+          }
+
+          const card = row.original
+          return (
+            card.cardId.toLowerCase().includes(search) ||
+            card.id.toLowerCase().includes(search) ||
+            card.owner.toLowerCase().includes(search)
+          )
+        },
+      },
+      {
+        accessorKey: 'owner',
+        header: ({ column }) => (
+          <Button
+            variant="ghost"
+            className="mx-auto -ml-2 h-8 px-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+          >
+            Owner
+          </Button>
+        ),
+        cell: ({ row }) => <span className="text-sm text-[#6E82A5]">{row.getValue('owner')}</span>,
+      },
+      {
+        accessorKey: 'accessibility',
+        header: () => (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Accessibility
+          </span>
+        ),
+        cell: ({ row }) => (
+          <span className="text-sm text-[#6E82A5]">{row.getValue('accessibility')}</span>
+        ),
+      },
+      {
+        accessorKey: 'status',
+        header: () => (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Status
+          </span>
+        ),
+        cell: ({ row }) => {
+          const status = row.getValue('status') as string
+          const isActive = status === 'Active'
+
+          return (
+            <Badge
+              className={cn(
+                'rounded-lg px-4 py-1 text-xs font-medium',
+                isActive
+                  ? 'bg-[#DFF8F3] text-[#0D8A72] hover:bg-[#DFF8F3] hover:text-[#0D8A72]'
+                  : 'bg-[#D1E9FF] text-[#40A3FF] hover:bg-[#D1E9FF] hover:text-[#40A3FF]'
+              )}
+            >
+              {status}
+            </Badge>
+          )
+        },
+      },
+      {
+        accessorKey: 'created',
+        header: () => (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Created
+          </span>
+        ),
+        cell: ({ row }) => (
+          <span className="whitespace-pre-line text-sm text-[#6E82A5]">
+            {row.getValue('created') as string}
+          </span>
+        ),
+      },
+      {
+        id: 'actions',
+        enableSorting: false,
+        enableHiding: false,
+        header: () => (
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Action
+          </span>
+        ),
+        cell: ({ row }) => {
+          const card = row.original
+
+          return (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-8 w-8 p-0">
+                  <span className="sr-only">Open menu</span>
+                  <MoreHorizontal className="h-4 w-4" />
                 </Button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                <DropdownMenuItem
+                  onClick={() => navigator.clipboard?.writeText(card.cardId)}
+                >
+                  Copy card ID
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => navigator.clipboard?.writeText(card.owner)}
+                >
+                  Copy owner name
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>View card details</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )
+        },
+      },
+    ],
+    [cards.length]
+  )
+
+  const table = useReactTable({
+    data: cards,
+    columns,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      rowSelection,
+    },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  })
+
+  const filterValue = (table.getColumn('cardId')?.getFilterValue() as string) ?? ''
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center">
+        <Input
+          placeholder="Search cards..."
+          value={filterValue}
+          onChange={(event) =>
+            table.getColumn('cardId')?.setFilterValue(event.target.value)
+          }
+          className="w-full max-w-sm"
+        />
+        <div className="flex flex-1 items-center justify-end gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="ml-auto">
+                Columns
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {table
+                .getAllColumns()
+                .filter((column) => column.getCanHide())
+                .map((column) => {
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={column.id}
+                      className="capitalize"
+                      checked={column.getIsVisible()}
+                      onCheckedChange={(value) =>
+                        column.toggleVisibility(!!value)
+                      }
+                    >
+                      {column.id}
+                    </DropdownMenuCheckboxItem>
+                  )
+                })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button className="h-10 text-xs sm:text-sm">
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            Add Card
+          </Button>
+        </div>
+      </div>
+      <div className="overflow-hidden rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    className={cn(
+                      centeredColumnIds.has(header.column.id)
+                        ? 'text-center'
+                        : 'text-left',
+                      header.column.id === 'select' && 'w-12'
+                    )}
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && 'selected'}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cn(
+                        centeredColumnIds.has(cell.column.id)
+                          ? 'text-center'
+                          : 'text-left'
+                      )}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex flex-col gap-2 py-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          {table.getFilteredSelectedRowModel().rows.length} of{' '}
+          {table.getFilteredRowModel().rows.length} row(s) selected.
+        </div>
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace the bespoke charge cards grid with a shadcn-style data table built on TanStack React Table, including selection, filtering, column visibility toggles, and pagination controls while preserving the original card/status styling
- streamline the charge cards tab to delegate filtering/search controls to the shared table implementation

## Testing
- pnpm lint *(fails: existing lint warnings across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc62a2f74832e9774a9e2a9530d62